### PR TITLE
Fix for loss of extra clips bug

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -32,7 +32,7 @@ AddEventHandler('weapons:server:AddWeaponAmmo', function(CurrentWeaponData, amou
 
     if CurrentWeaponData ~= nil then
         if Player.PlayerData.items[CurrentWeaponData.slot] ~= nil then
-            Player.PlayerData.items[CurrentWeaponData.slot].info.ammo = amount
+            Player.PlayerData.items[CurrentWeaponData.slot].info.ammo = Player.PlayerData.items[CurrentWeaponData.slot].info.ammo + amount
         end
         Player.Functions.SetInventory(Player.PlayerData.items, true)
     end


### PR DESCRIPTION
AddWeaponAmmo was actually setting the ammo data to a single clip. So if you loaded multiple clips, then swapped weapons or put your weapon away, when you took it back out you'd only have a single clip of ammo (for example, 3 rifle mags having 60|30 ammo would go to 0|30 ammo when pulling it back out). This adds the new amount to the original amount, fixing the bug so you don't lose additional loaded ammo