### PR TITLE
Fixes Ammo Saving

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -1,14 +1,9 @@
 Config = Config or {}
 
 Config.DurabilityBlockedWeapons = {
---[[     "weapon_pistol_mk2",
-    "weapon_pistol",
     "weapon_stungun",
-    "weapon_pumpshotgun",
-    "weapon_smg",
-    "weapon_carbinerifle",
     "weapon_nightstick",
-    "weapon_flashlight", ]]
+    "weapon_flashlight",
     "weapon_unarmed",
 }
 


### PR DESCRIPTION
Apparently as weapons were DurabilityCheck ignored, they weren't saving their ammo properly.....even if the code part was commented out....not sure tbh but it's all I changed and ammo started working properly again on all weaps,