### PR TITLE
fix: notify spam after breaking a weapon

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -42,7 +42,6 @@ Citizen.CreateThread(function()
                         else
                             TriggerEvent('inventory:client:CheckWeapon', QBCore.Shared.Weapons[weapon]["name"])
                             QBCore.Functions.Notify("This weapon is broken and can not be used..", "error")
-                            print(GetSelectedPedWeapon(PlayerPedId()))
                             MultiplierAmount = 0
                         end
                     end

--- a/client/main.lua
+++ b/client/main.lua
@@ -37,10 +37,14 @@ Citizen.CreateThread(function()
                             end
                         end
                     else
-			local weapon = GetSelectedPedWeapon(ped)
-                        TriggerEvent('inventory:client:CheckWeapon', QBCore.Shared.Weapons[weapon]["name"])
-                        QBCore.Functions.Notify("This weapon is broken and can not be used..", "error")
-                        MultiplierAmount = 0
+			            local weapon = GetSelectedPedWeapon(ped)
+                        if weapon == -1569615261 then
+                        else
+                            TriggerEvent('inventory:client:CheckWeapon', QBCore.Shared.Weapons[weapon]["name"])
+                            QBCore.Functions.Notify("This weapon is broken and can not be used..", "error")
+                            print(GetSelectedPedWeapon(PlayerPedId()))
+                            MultiplierAmount = 0
+                        end
                     end
                 end
             end

--- a/client/main.lua
+++ b/client/main.lua
@@ -38,8 +38,7 @@ Citizen.CreateThread(function()
                         end
                     else
 			            local weapon = GetSelectedPedWeapon(ped)
-                        if weapon == -1569615261 then
-                        else
+                        if weapon ~= -1569615261 then
                             TriggerEvent('inventory:client:CheckWeapon', QBCore.Shared.Weapons[weapon]["name"])
                             QBCore.Functions.Notify("This weapon is broken and can not be used..", "error")
                             MultiplierAmount = 0


### PR DESCRIPTION
fixes #22 , however I could not replicate the issue with the gun giving ammo. Testing with  `/setammo` and also using the ammo item