### PR TITLE
Remove weapons:server:UpdateWeaponAmmo to 0

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -92,7 +92,6 @@ Citizen.CreateThread(function()
                 TriggerServerEvent("weapons:server:UpdateWeaponAmmo", CurrentWeaponData, tonumber(ammo))
             else
                 TriggerEvent('inventory:client:CheckWeapon')
-                TriggerServerEvent("weapons:server:UpdateWeaponAmmo", CurrentWeaponData, 0)
             end
 
             if MultiplierAmount > 0 then


### PR DESCRIPTION
TriggerServerEvent("weapons:server:UpdateWeaponAmmo", CurrentWeaponData, 0) This event inside the else statement sets weapon ammunition to 0 if the player is spamming between unarmed and a weapon. This is because the script will check for ammunition amount on unarmed as well as the weapon and has a tendency to get confused and then set your weapon ammo to 0 because your unarmed ammo returns 0.

Commenting this out will still check your weapon when it is out of ammo and prevent you from shooting; however, if won't cause your ammo to delete if you have ammo and then spam between armed and unarmed.