### PR TITLE
fix(client/shooting): Check if weapon exists first

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -155,36 +155,37 @@ CreateThread(function()
             local ped = PlayerPedId()
             if CurrentWeaponData and next(CurrentWeaponData) then
                 if IsPedShooting(ped) or IsControlJustPressed(0, 24) then
+                    local weapon = GetSelectedPedWeapon(ped)
                     if CanShoot then
-                        local weapon = GetSelectedPedWeapon(ped)
-                        local ammo = GetAmmoInPedWeapon(ped, weapon)
-                        if QBCore.Shared.Weapons[weapon]["name"] == "weapon_snowball" then
-                            TriggerServerEvent('QBCore:Server:RemoveItem', "snowball", 1)
-                        elseif QBCore.Shared.Weapons[weapon]["name"] == "weapon_pipebomb" then
-                            TriggerServerEvent('QBCore:Server:RemoveItem', "weapon_pipebomb", 1)
-                        elseif QBCore.Shared.Weapons[weapon]["name"] == "weapon_molotov" then
-                            TriggerServerEvent('QBCore:Server:RemoveItem', "weapon_molotov", 1)
-                        elseif QBCore.Shared.Weapons[weapon]["name"] == "weapon_stickybomb" then
-                            TriggerServerEvent('QBCore:Server:RemoveItem', "weapon_stickybomb", 1)
-                        elseif QBCore.Shared.Weapons[weapon]["name"] == "weapon_grenade" then
-                            TriggerServerEvent('QBCore:Server:RemoveItem', "weapon_grenade", 1)
-                        elseif QBCore.Shared.Weapons[weapon]["name"] == "weapon_bzgas" then
-                            TriggerServerEvent('QBCore:Server:RemoveItem', "weapon_bzgas", 1)
-                        elseif QBCore.Shared.Weapons[weapon]["name"] == "weapon_proxmine" then
-                            TriggerServerEvent('QBCore:Server:RemoveItem', "weapon_proxmine", 1)
-                        elseif QBCore.Shared.Weapons[weapon]["name"] == "weapon_ball" then
-                            TriggerServerEvent('QBCore:Server:RemoveItem', "weapon_ball", 1)
-                        elseif QBCore.Shared.Weapons[weapon]["name"] == "weapon_smokegrenade" then
-                            TriggerServerEvent('QBCore:Server:RemoveItem', "weapon_smokegrenade", 1)
-                        elseif QBCore.Shared.Weapons[weapon]["name"] == "weapon_flare" then
-                            TriggerServerEvent('QBCore:Server:RemoveItem', "weapon_flare", 1)
-                        else
-                            if ammo > 0 then
-                                MultiplierAmount = MultiplierAmount + 1
+                        if weapon and weapon ~= 0 and QBCore.Shared.Weapons[weapon] then
+                            local ammo = GetAmmoInPedWeapon(ped, weapon)
+                            if QBCore.Shared.Weapons[weapon]["name"] == "weapon_snowball" then
+                                TriggerServerEvent('QBCore:Server:RemoveItem', "snowball", 1)
+                            elseif QBCore.Shared.Weapons[weapon]["name"] == "weapon_pipebomb" then
+                                TriggerServerEvent('QBCore:Server:RemoveItem', "weapon_pipebomb", 1)
+                            elseif QBCore.Shared.Weapons[weapon]["name"] == "weapon_molotov" then
+                                TriggerServerEvent('QBCore:Server:RemoveItem', "weapon_molotov", 1)
+                            elseif QBCore.Shared.Weapons[weapon]["name"] == "weapon_stickybomb" then
+                                TriggerServerEvent('QBCore:Server:RemoveItem', "weapon_stickybomb", 1)
+                            elseif QBCore.Shared.Weapons[weapon]["name"] == "weapon_grenade" then
+                                TriggerServerEvent('QBCore:Server:RemoveItem', "weapon_grenade", 1)
+                            elseif QBCore.Shared.Weapons[weapon]["name"] == "weapon_bzgas" then
+                                TriggerServerEvent('QBCore:Server:RemoveItem', "weapon_bzgas", 1)
+                            elseif QBCore.Shared.Weapons[weapon]["name"] == "weapon_proxmine" then
+                                TriggerServerEvent('QBCore:Server:RemoveItem', "weapon_proxmine", 1)
+                            elseif QBCore.Shared.Weapons[weapon]["name"] == "weapon_ball" then
+                                TriggerServerEvent('QBCore:Server:RemoveItem', "weapon_ball", 1)
+                            elseif QBCore.Shared.Weapons[weapon]["name"] == "weapon_smokegrenade" then
+                                TriggerServerEvent('QBCore:Server:RemoveItem', "weapon_smokegrenade", 1)
+                            elseif QBCore.Shared.Weapons[weapon]["name"] == "weapon_flare" then
+                                TriggerServerEvent('QBCore:Server:RemoveItem', "weapon_flare", 1)
+                            else
+                                if ammo > 0 then
+                                    MultiplierAmount = MultiplierAmount + 1
+                                end
                             end
                         end
                     else
-			            local weapon = GetSelectedPedWeapon(ped)
                         if weapon ~= -1569615261 then
                             TriggerEvent('inventory:client:CheckWeapon', QBCore.Shared.Weapons[weapon]["name"])
                             QBCore.Functions.Notify("This weapon is broken and can not be used.", "error")


### PR DESCRIPTION
This makes sure to check whether the weapon exists in the shared or not as this is a very high speed loop this will sometimes return nothing when you switch weapons or holster it