### PR TITLE
Add ReloadTime Config, Change reload native

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -81,7 +81,7 @@ RegisterNetEvent('weapon:client:AddAmmo', function(type, amount, itemData)
             local total = GetAmmoInPedWeapon(ped, weapon)
             local found, maxAmmo = GetMaxAmmo(ped, weapon)
             if total < maxAmmo then
-                QBCore.Functions.Progressbar("taking_bullets", Lang:t('info.loading_bullets'), math.random(4000, 6000), false, true, {
+                QBCore.Functions.Progressbar("taking_bullets", Lang:t('info.loading_bullets'), Config.ReloadTime, false, true, {
                     disableMovement = false,
                     disableCarMovement = false,
                     disableMouse = false,
@@ -89,7 +89,7 @@ RegisterNetEvent('weapon:client:AddAmmo', function(type, amount, itemData)
                 }, {}, {}, {}, function() -- Done
                     if QBCore.Shared.Weapons[weapon] then
                         AddAmmoToPed(ped,weapon,amount)
-                        TaskReloadWeapon(ped)
+                        MakePedReload(ped)
                         TriggerServerEvent("weapons:server:AddWeaponAmmo", CurrentWeaponData, total + amount)
                         TriggerServerEvent('QBCore:Server:RemoveItem', itemData.name, 1, itemData.slot)
                         TriggerEvent('inventory:client:ItemBox', QBCore.Shared.Items[itemData.name], "remove")

--- a/config.lua
+++ b/config.lua
@@ -1,5 +1,7 @@
 Config = Config or {}
 
+Config.ReloadTime = math.random(4000, 6000)
+
 Config.DurabilityBlockedWeapons = {
     "weapon_stungun",
     "weapon_nightstick",


### PR DESCRIPTION
Add `Config.ReloadTime` for people to adjust their own time to load bullets
Change `TaskReloadWeapon` to `MakePedReload` - Does the same thing, however it doesn't force them to come to a complete stop when loading ammo, and only makes them reload when they have to