### PR TITLE
Fix to a major ammo glitch

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -50,7 +50,7 @@ QBCore.Functions.CreateCallback("weapon:server:GetWeaponAmmo", function(source, 
             end
         end
     end
-    cb(retval)
+    cb(retval, WeaponData.name)
 end)
 
 QBCore.Functions.CreateCallback('weapons:server:RemoveAttachment', function(source, cb, AttachmentData, ItemData)


### PR DESCRIPTION
Suppose you have any loaded gun in slot 1 and a empty gun in slot 2. You just pull up your 1slot gun, shoot few bullet(not necessary) then put it in pocket, then press 1 and 2 at the same time in such a way that the gun at slot 2 comes atlast, and you get ur 1st slot weapon ammo copied to 2nd slot weapon. Try it! 
I hope I you understood what i tried to tell!


There are more fixes in qb-inventory
