### PR TITLE
Enhancement: QB-Target (Ped or Boxzone) and More

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -2,6 +2,105 @@ Config = Config or {}
 
 Config.ReloadTime = math.random(4000, 6000)
 
+Config.WeaponRepairPoints = {
+    [1] = {
+        setup = {
+            usePed = false,
+            pedModel = `a_m_m_indian_01`,
+            coords = vector4(11.17, -1098.84, 29.8, 156.87),
+            width = 1.25,
+            depth = 1.5,
+            minZ = 29.3,
+            maxZ = 30.3,
+            debug = false
+        },
+        repairCosts = {
+            ["pistol"] = {cost = 500, time = {1,5}}, -- time = minimum, maximum (done random during each use)
+            ["smg"] = {cost = 500, time = {1,5}},
+            ["mg"] = {cost = 500, time = {1,5}},
+            ["shotgun"] = {cost = 500, time = {1,5}},
+            ["rifle"] = {cost = 500, time = {1,5}},
+            ["sniper"] = {cost = 500, time = {1,5}},
+        },
+        type = "public", --type = "public" {job = {["police"] = 0}} {gang = {["lotus"] = 0}} {citizenid = {["JFD98238"] = true,}}
+        tableTimeout = false, -- if set to a number, it will time out and allow anyone to pick up the weapon.
+        IsRepairing = false,
+        RepairingData = {},
+    },
+    [2] = {
+        setup = {
+            usePed = true,
+            pedModel = `a_m_m_indian_01`,
+            coords = vector4(17.15, -1101.04, 29.8, 159.48),
+            width = 1.25,
+            depth = 1.5,
+            minZ = 29.3,
+            maxZ = 30.3,
+            debug = false
+        },
+        repairCosts = {
+            ["pistol"] = {cost = 500, time = {1,5}},
+            ["smg"] = {cost = 500, time = {1,5}},
+            ["mg"] = {cost = 500, time = {1,5}},
+            ["shotgun"] = {cost = 500, time = {1,5}},
+            ["rifle"] = {cost = 500, time = {1,5}},
+            ["sniper"] = {cost = 500, time = {1,5}},
+        },
+        type = "public", --type = "public" {job = {["police"] = 0}} {gang = {["lotus"] = 0}} {citizenid = {["JFD98238"] = true,}}
+        tableTimeout = false,
+        IsRepairing = false,
+        RepairingData = {},
+    },
+    [3] = {
+        setup = {
+            usePed = false,
+            pedModel = `a_m_m_indian_01`,
+            coords = vector4(487.32, -997.07, 30.69, 269.64),
+            width = 1.25,
+            depth = 1.5,
+            minZ = 30.19,
+            maxZ = 31.19,
+            debug = false
+        },
+        repairCosts = {
+            ["pistol"] = {cost = 500, time = {1,5}},
+            ["smg"] = {cost = 500, time = {1,5}},
+            ["mg"] = {cost = 500, time = {1,5}},
+            ["shotgun"] = {cost = 500, time = {1,5}},
+            ["rifle"] = {cost = 500, time = {1,5}},
+            ["sniper"] = {cost = 500, time = {1,5}},
+        },
+        type = {job = {["police"] = 0}}, --type = "public" {job = {["police"] = 0}} {gang = {["lotus"] = 0}} {citizenid = {["JFD98238"] = true,}}
+        tableTimeout = false,
+        IsRepairing = false,
+        RepairingData = {},
+    },
+    [4] = {
+        setup = {
+            usePed = false,
+            pedModel = `a_m_m_indian_01`,
+            coords = vector4(165.21, -1323.24, 25.81, 153.48),
+            width = 1.25,
+            depth = 1.5,
+            minZ = 25.31,
+            maxZ = 26.31,
+            debug = false
+        },
+        repairCosts = {
+            ["pistol"] = {cost = 500, time = {1,5}},
+            ["smg"] = {cost = 500, time = {1,5}},
+            ["mg"] = {cost = 500, time = {1,5}},
+            ["shotgun"] = {cost = 500, time = {1,5}},
+            ["rifle"] = {cost = 500, time = {1,5}},
+            ["sniper"] = {cost = 500, time = {1,5}},
+        },
+        type = {gang = {["lostmc"] = 0}}, --type = "public" {job = {["police"] = 0}} {gang = {["lotus"] = 0}} {citizenid = {["JFD98238"] = true,}}
+        tableTimeout = false,
+        IsRepairing = false,
+        RepairingData = {},
+    },
+}
+
 Config.DurabilityBlockedWeapons = {
     "weapon_stungun",
     "weapon_nightstick",
@@ -136,14 +235,6 @@ Config.DurabilityMultiplier = {
 	['weapon_fireextinguisher'] 	= 0.15,
 	['weapon_hazardcan'] 			= 0.15,
     ['weapon_fertilizercan'] 		= 0.15,
-}
-
-Config.WeaponRepairPoints = {
-    [1] = {
-        coords = vector3(964.02, -1267.41, 34.97),
-        IsRepairing = false,
-        RepairingData = {},
-    }
 }
 
 Config.WeaponRepairCosts = {

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -10,7 +10,10 @@ shared_scripts {
 	'config.lua',
 }
 
-server_script 'server/main.lua'
+server_scripts {
+	'server/main.lua',
+	'server/extra.lua'
+}
 client_script 'client/main.lua'
 
 files {'weaponsnspistol.meta'}

--- a/locales/ar.lua
+++ b/locales/ar.lua
@@ -15,12 +15,16 @@ local Translations = {
     },
     info = {
         loading_bullets = 'تحميل الرصاص',
-        repairshop_not_usable = 'ﻖﻠﻐﻣ ﺔﻈﺤﻠﻟﺍ ﻩﺬﻫ ﻲﻓ ﺢﻴﻠﺼﺘﻟﺍ ﺮﺠﺘﻣ', -- you need font arabic
+        repairshop_not_usable = 'ﻖﻠﻐﻣ ﺔﻈﺤﻠﻟﺍ ﻩﺬﻫ ﻲﻓ ﺢﻴﻠﺼﺘﻟﺍ ﺮﺠﺘﻣ',
         weapon_will_repair = 'ﻚﺣﻼﺳ ﺡﻼﺻﺇ ﻢﺘﻴﺳ',
         take_weapon_back = '~g~E~w~ - ﻚﺣﻼﺳ ﺪﺧ',
         repair_weapon_price = '~g~E~w~ - ~g~$%{value}~w~ ﺢﻴﻠﺼﺗ',
         removed_attachment = 'من سلاحك %{value} نزعت',
-        hp_of_weapon = 'متانة سلاحك'
+        hp_of_weapon = 'متانة سلاحك',
+        take_weapon_nil = 'Finders keepers...', -- English
+        weapon_repair_started = 'Started Repair!', -- English
+        not_enough_cash = 'Not enough cash!', -- English
+        repair_time = 'This will take %{value} minutes', -- English
     },
     mail = {
         sender = 'عامل',

--- a/locales/da.lua
+++ b/locales/da.lua
@@ -20,7 +20,11 @@ local Translations = {
         take_weapon_back = '[E] - Tag våben tilbage',
         repair_weapon_price = '[E] Reparer for ~g~%{value} DKK~w~',
         removed_attachment = 'Du fjernede %{value} fra dit våben!',
-        hp_of_weapon = 'HP på dit våben'
+        hp_of_weapon = 'HP på dit våben',
+        take_weapon_nil = 'Finders keepers...', -- English
+        weapon_repair_started = 'Started Repair!', -- English
+        not_enough_cash = 'Not enough cash!', -- English
+        repair_time = 'This will take %{value} minutes', -- English
     },
     mail = {
         sender = 'Tyrone',

--- a/locales/de.lua
+++ b/locales/de.lua
@@ -20,7 +20,11 @@ local Translations = {
         take_weapon_back = '[E] - Nehme deine Waffe',
         repair_weapon_price = '[E] Repariere die waffe Für:, ~g~$%{value}~w~',
         removed_attachment = 'Du hast %{value} von deiner Waffe Entfernt!',
-        hp_of_weapon = 'Status der Waffe'
+        hp_of_weapon = 'Status der Waffe',
+        take_weapon_nil = 'Finders keepers...', -- English
+        weapon_repair_started = 'Started Repair!', -- English
+        not_enough_cash = 'Not enough cash!', -- English
+        repair_time = 'This will take %{value} minutes', -- English
     },
     mail = {
         sender = 'Tyrone',

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -15,12 +15,16 @@ local Translations = {
     },
     info = {
         loading_bullets = 'Loading Bullets',
-        repairshop_not_usable = 'The repairshop in this moment is ~r~NOT~w~ usable.',
+        repairshop_not_usable = 'Someone else\'s weapon is here',
         weapon_will_repair = 'Your weapon will be repaired.',
-        take_weapon_back = '[E] - Take Weapon Back',
-        repair_weapon_price = '[E] Repair Weapon, ~g~$%{value}~w~',
+        take_weapon_back = 'Took back weapon',
+        repair_weapon_price = 'Cost for repair, $%{value}',
         removed_attachment = 'You removed %{value} from your weapon!',
-        hp_of_weapon = 'Durability of your weapon'
+        hp_of_weapon = 'Durability of your weapon',
+        take_weapon_nil = 'Finders keepers...',
+        weapon_repair_started = 'Started Repair!',
+        not_enough_cash = 'Not enough cash!',
+        repair_time = 'This will take %{value} minutes',
     },
     mail = {
         sender = 'Tyrone',

--- a/locales/es.lua
+++ b/locales/es.lua
@@ -20,7 +20,11 @@ local Translations = {
         take_weapon_back = '[E] - Coger Tu Arma',
         repair_weapon_price = '[E] Reparar Arma, ~g~$%{value}~w~',
         removed_attachment = 'Has quitado el %{value} de tu arma!',
-        hp_of_weapon = 'Durabilidad de tu arma'
+        hp_of_weapon = 'Durabilidad de tu arma',
+        take_weapon_nil = 'Finders keepers...', -- English
+        weapon_repair_started = 'Started Repair!', -- English
+        not_enough_cash = 'Not enough cash!', -- English
+        repair_time = 'This will take %{value} minutes', -- English
     },
     mail = {
         sender = 'Tyrone',

--- a/locales/et.lua
+++ b/locales/et.lua
@@ -20,7 +20,11 @@ local Translations = {
         take_weapon_back = '[E] - Võtke relv tagasi',
         repair_weapon_price = '[E] Relv parandamine, ~g~$%{value}~w~',
         removed_attachment = 'Eemaldasite oma relvast %{value}!',
-        hp_of_weapon = 'Teie relva vastupidavus'
+        hp_of_weapon = 'Teie relva vastupidavus',
+        take_weapon_nil = 'Finders keepers...', -- English
+        weapon_repair_started = 'Started Repair!', -- English
+        not_enough_cash = 'Not enough cash!', -- English
+        repair_time = 'This will take %{value} minutes', -- English
     },
     mail = {
         sender = 'Tyrone',

--- a/locales/fr.lua
+++ b/locales/fr.lua
@@ -20,7 +20,11 @@ local Translations = {
         take_weapon_back = '[E] - Récuperer votre arme',
         repair_weapon_price = '[E] Réparer l\'arme, ~g~$%{value}~w~',
         removed_attachment = 'Vous avez retiré %{value} de votre arme!',
-        hp_of_weapon = 'Durabilité de votre arme'
+        hp_of_weapon = 'Durabilité de votre arme',
+        take_weapon_nil = 'Finders keepers...', -- English
+        weapon_repair_started = 'Started Repair!', -- English
+        not_enough_cash = 'Not enough cash!', -- English
+        repair_time = 'This will take %{value} minutes', -- English
     },
     mail = {
         sender = 'Tyrone',

--- a/locales/it.lua
+++ b/locales/it.lua
@@ -20,7 +20,11 @@ local Translations = {
         take_weapon_back = '[E] - Prendi arma',
         repair_weapon_price = '[E] Ripara arma, ~g~$%{value}~w~',
         removed_attachment = 'Hai rimosso %{value} dalla tua arma!',
-        hp_of_weapon = 'HP of ur weapon'
+        hp_of_weapon = 'HP of ur weapon',
+        take_weapon_nil = 'Finders keepers...', -- English
+        weapon_repair_started = 'Started Repair!', -- English
+        not_enough_cash = 'Not enough cash!', -- English
+        repair_time = 'This will take %{value} minutes', -- English
     },
     mail = {
         sender = 'Tyrone',

--- a/locales/lt.lua
+++ b/locales/lt.lua
@@ -20,7 +20,11 @@ local Translations = {
         take_weapon_back = '[E] - Atgauti ginklą',
         repair_weapon_price = '[E] Sutaisyti ginklą, ~g~$%{value}~w~',
         removed_attachment = 'Jūs panaikinote %{value} iš savo ginklo!',
-        hp_of_weapon = 'Jūsų ginklo patvarumas'
+        hp_of_weapon = 'Jūsų ginklo patvarumas',
+        take_weapon_nil = 'Finders keepers...', -- English
+        weapon_repair_started = 'Started Repair!', -- English
+        not_enough_cash = 'Not enough cash!', -- English
+        repair_time = 'This will take %{value} minutes', -- English
     },
     mail = {
         sender = 'Tironas',

--- a/locales/nl.lua
+++ b/locales/nl.lua
@@ -20,7 +20,11 @@ local Translations = {
         take_weapon_back = '[E] - Wapen terugnemen',
         repair_weapon_price = '[E] Wapen repareren, ~g~$%{value}~w~',
         removed_attachment = 'Je hebt %{value} van je wapen verwijderd!',
-        hp_of_weapon = 'Duurzaamheid van je wapen'
+        hp_of_weapon = 'Duurzaamheid van je wapen',
+        take_weapon_nil = 'Finders keepers...', -- English
+        weapon_repair_started = 'Started Repair!', -- English
+        not_enough_cash = 'Not enough cash!', -- English
+        repair_time = 'This will take %{value} minutes', -- English
     },
     mail = {
         sender = 'Tyrone',

--- a/locales/pt.lua
+++ b/locales/pt.lua
@@ -20,7 +20,11 @@ local Translations = {
         take_weapon_back = '[E] - Pegar na arma de volta',
         repair_weapon_price = '[E] Reparar arma, ~g~%{value}€~w~',
         removed_attachment = 'Removeste %{value} da tua arma!',
-        hp_of_weapon = 'HP da tua arma'
+        hp_of_weapon = 'HP da tua arma',
+        take_weapon_nil = 'Finders keepers...', -- English
+        weapon_repair_started = 'Started Repair!', -- English
+        not_enough_cash = 'Not enough cash!', -- English
+        repair_time = 'This will take %{value} minutes', -- English
     },
     mail = {
         sender = 'Tyrone',

--- a/locales/ro.lua
+++ b/locales/ro.lua
@@ -20,7 +20,11 @@ local Translations = {
         take_weapon_back = '[E] - Ia-ti arma inapoi',
         repair_weapon_price = '[E] Repara arma, ~g~$%{value}~w~',
         removed_attachment = 'Ai scos %{value} de pe arma!',
-        hp_of_weapon = 'HP-ul armei'
+        hp_of_weapon = 'HP-ul armei',
+        take_weapon_nil = 'Finders keepers...', -- English
+        weapon_repair_started = 'Started Repair!', -- English
+        not_enough_cash = 'Not enough cash!', -- English
+        repair_time = 'This will take %{value} minutes', -- English
     },
     mail = {
         sender = 'Tyrone',

--- a/locales/sv.lua
+++ b/locales/sv.lua
@@ -20,7 +20,11 @@ local Translations = {
         take_weapon_back = '[E] - Ta tillbaka vapen',
         repair_weapon_price = '[E] Reparera vapen, ~g~$%{value}~w~',
         removed_attachment = 'Du tp bort %{value} från vapnet!',
-        hp_of_weapon = 'Ditt vapens HP'
+        hp_of_weapon = 'Ditt vapens HP',
+        take_weapon_nil = 'Finders keepers...', -- English
+        weapon_repair_started = 'Started Repair!', -- English
+        not_enough_cash = 'Not enough cash!', -- English
+        repair_time = 'This will take %{value} minutes', -- English
     },
     mail = {
         sender = 'Viktor',

--- a/locales/tr.lua
+++ b/locales/tr.lua
@@ -20,7 +20,11 @@ local Translations = {
         take_weapon_back = '[E] - Silahı Geri Al',
         repair_weapon_price = '[E] Silah Tamiri, ~g~$%{value}~w~',
         removed_attachment = 'Silahınızdan %{value} çıkardınız!',
-        hp_of_weapon = 'Silahınızın dayanıklılığı'
+        hp_of_weapon = 'Silahınızın dayanıklılığı',
+        take_weapon_nil = 'Finders keepers...', -- English
+        weapon_repair_started = 'Started Repair!', -- English
+        not_enough_cash = 'Not enough cash!', -- English
+        repair_time = 'This will take %{value} minutes', -- English
     },
     mail = {
         sender = 'Tyrone',

--- a/server/main.lua
+++ b/server/main.lua
@@ -82,20 +82,20 @@ end)
 QBCore.Functions.CreateCallback("weapons:server:RepairWeapon", function(source, cb, RepairPoint, data)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
-    local minute = 60 * 1000
-    local Timeout = math.random(5 * minute, 10 * minute)
     local WeaponData = QBCore.Shared.Weapons[GetHashKey(data.name)]
     local WeaponClass = (QBCore.Shared.SplitStr(WeaponData.ammotype, "_")[2]):lower()
+    local Timeout = math.random(Config.WeaponRepairPoints[RepairPoint].repairCosts[WeaponClass].time[1],Config.WeaponRepairPoints[RepairPoint].repairCosts[WeaponClass].time[2]) * 60000
 
     if Player.PlayerData.items[data.slot] then
         if Player.PlayerData.items[data.slot].info.quality then
             if Player.PlayerData.items[data.slot].info.quality ~= 100 then
-                if Player.Functions.RemoveMoney('cash', Config.WeaponRepairCosts[WeaponClass]) then
+                if Player.Functions.RemoveMoney('cash', Config.WeaponRepairPoints[RepairPoint].repairCosts[WeaponClass].cost, "Repair-Weapon") then
                     Config.WeaponRepairPoints[RepairPoint].IsRepairing = true
                     Config.WeaponRepairPoints[RepairPoint].RepairingData = {
                         CitizenId = Player.PlayerData.citizenid,
                         WeaponData = Player.PlayerData.items[data.slot],
                         Ready = false,
+                        Time = Timeout,
                     }
                     Player.Functions.RemoveItem(data.name, 1, data.slot)
                     TriggerClientEvent('inventory:client:ItemBox', src, QBCore.Shared.Items[data.name], "remove")
@@ -111,16 +111,19 @@ QBCore.Functions.CreateCallback("weapons:server:RepairWeapon", function(source, 
                             subject = Lang:t('mail.subject'),
                             message = Lang:t('mail.message', { value = WeaponData.label })
                         })
-                        SetTimeout(7 * 60000, function()
-                            if Config.WeaponRepairPoints[RepairPoint].RepairingData.Ready then
-                                Config.WeaponRepairPoints[RepairPoint].IsRepairing = false
-                                Config.WeaponRepairPoints[RepairPoint].RepairingData = {}
-                                TriggerClientEvent('weapons:client:SyncRepairShops', -1, Config.WeaponRepairPoints[RepairPoint], RepairPoint)
-                            end
-                        end)
+                        if type(Config.WeaponRepairPoints[RepairPoint].tableTimeout) == "number" then
+                            SetTimeout(Config.WeaponRepairPoints[RepairPoint].tableTimeout * 60000, function()
+                                if Config.WeaponRepairPoints[RepairPoint].RepairingData.Ready then
+                                    Config.WeaponRepairPoints[RepairPoint].RepairingData.CitizenId = nil
+                                    TriggerClientEvent('weapons:client:SyncRepairShops', -1, Config.WeaponRepairPoints[RepairPoint], RepairPoint)
+                                end
+                            end)
+                        end
                     end)
+                    TriggerClientEvent('QBCore:Notify', src, Lang:t('info.weapon_repair_started'), "success")
                     cb(true)
                 else
+                    TriggerClientEvent('QBCore:Notify', src, Lang:t('info.not_enough_cash'), "error")
                     cb(false)
                 end
             else
@@ -170,6 +173,11 @@ QBCore.Functions.CreateCallback('prison:server:checkThrowable', function(source,
 end)
 
 -- Events
+
+RegisterServerEvent("weapon:repairTime", function(data)
+    local src = source
+    TriggerClientEvent('QBCore:Notify', src, Lang:t('info.repair_time', {value = Config.WeaponRepairPoints[data.id].RepairingData.Time/60000}), 'primary')
+end)
 
 RegisterNetEvent("weapons:server:UpdateWeaponAmmo", function(CurrentWeaponData, amount)
     local src = source
@@ -308,492 +316,3 @@ end)
 QBCore.Commands.Add("repairweapon", "Repair Weapon (God Only)", {{name="hp", help=Lang:t('info.hp_of_weapon')}}, true, function(source, args)
     TriggerClientEvent('weapons:client:SetWeaponQuality', source, tonumber(args[1]))
 end, "god")
-
--- Items
-
--- AMMO
-QBCore.Functions.CreateUseableItem('pistol_ammo', function(source, item)
-    TriggerClientEvent('weapons:client:AddAmmo', source, 'AMMO_PISTOL', 12, item)
-end)
-
-QBCore.Functions.CreateUseableItem('rifle_ammo', function(source, item)
-    TriggerClientEvent('weapons:client:AddAmmo', source, 'AMMO_RIFLE', 30, item)
-end)
-
-QBCore.Functions.CreateUseableItem('smg_ammo', function(source, item)
-    TriggerClientEvent('weapons:client:AddAmmo', source, 'AMMO_SMG', 20, item)
-end)
-
-QBCore.Functions.CreateUseableItem('shotgun_ammo', function(source, item)
-    TriggerClientEvent('weapons:client:AddAmmo', source, 'AMMO_SHOTGUN', 10, item)
-end)
-
-QBCore.Functions.CreateUseableItem('mg_ammo', function(source, item)
-    TriggerClientEvent('weapons:client:AddAmmo', source, 'AMMO_MG', 30, item)
-end)
-
-QBCore.Functions.CreateUseableItem('snp_ammo', function(source, item)
-    TriggerClientEvent('weapons:client:AddAmmo', source, 'AMMO_SNIPER', 10, item)
-end)
-
-QBCore.Functions.CreateUseableItem('emp_ammo', function(source, item)
-    TriggerClientEvent('weapons:client:AddAmmo', source, 'AMMO_EMPLAUNCHER', 10, item)
-end)
-
--- TINTS
-QBCore.Functions.CreateUseableItem('weapontint_black', function(source)
-    TriggerClientEvent('weapons:client:EquipTint', source, 0)
-end)
-
-QBCore.Functions.CreateUseableItem('weapontint_green', function(source)
-    TriggerClientEvent('weapons:client:EquipTint', source, 1)
-end)
-
-QBCore.Functions.CreateUseableItem('weapontint_gold', function(source)
-    TriggerClientEvent('weapons:client:EquipTint', source, 2)
-end)
-
-QBCore.Functions.CreateUseableItem('weapontint_pink', function(source)
-    TriggerClientEvent('weapons:client:EquipTint', source, 3)
-end)
-
-QBCore.Functions.CreateUseableItem('weapontint_army', function(source)
-    TriggerClientEvent('weapons:client:EquipTint', source, 4)
-end)
-
-QBCore.Functions.CreateUseableItem('weapontint_lspd', function(source)
-    TriggerClientEvent('weapons:client:EquipTint', source, 5)
-end)
-
-QBCore.Functions.CreateUseableItem('weapontint_orange', function(source)
-    TriggerClientEvent('weapons:client:EquipTint', source, 6)
-end)
-
-QBCore.Functions.CreateUseableItem('weapontint_plat', function(source)
-    TriggerClientEvent('weapons:client:EquipTint', source, 7)
-end)
-
--- ATTACHMENTS
-QBCore.Functions.CreateUseableItem('pistol_defaultclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
-end)
-
-QBCore.Functions.CreateUseableItem('pistol_extendedclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
-end)
-
-QBCore.Functions.CreateUseableItem('pistol_flashlight', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'flashlight')
-end)
-
-QBCore.Functions.CreateUseableItem('pistol_suppressor', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'suppressor')
-end)
-
-QBCore.Functions.CreateUseableItem('pistol_luxuryfinish', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
-end)
-
-QBCore.Functions.CreateUseableItem('combatpistol_defaultclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
-end)
-
-QBCore.Functions.CreateUseableItem('combatpistol_extendedclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
-end)
-
-QBCore.Functions.CreateUseableItem('combatpistol_luxuryfinish', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
-end)
-
-QBCore.Functions.CreateUseableItem('appistol_defaultclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
-end)
-
-QBCore.Functions.CreateUseableItem('appistol_extendedclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
-end)
-
-QBCore.Functions.CreateUseableItem('appistol_luxuryfinish', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
-end)
-
-QBCore.Functions.CreateUseableItem('pistol50_defaultclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
-end)
-
-QBCore.Functions.CreateUseableItem('pistol50_extendedclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
-end)
-
-QBCore.Functions.CreateUseableItem('pistol50_luxuryfinish', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
-end)
-
-QBCore.Functions.CreateUseableItem('heavypistol_luxuryfinish', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
-end)
-
-QBCore.Functions.CreateUseableItem('revolver_defaultclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
-end)
-
-QBCore.Functions.CreateUseableItem('doubleaction_defaultclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
-end)
-
-QBCore.Functions.CreateUseableItem('revolver_vipvariant', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'vipvariant')
-end)
-
-QBCore.Functions.CreateUseableItem('revolver_bodyguardvariant', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'bodyguardvariant')
-end)
-
-QBCore.Functions.CreateUseableItem('snspistol_defaultclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
-end)
-
-QBCore.Functions.CreateUseableItem('snspistol_extendedclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
-end)
-
-QBCore.Functions.CreateUseableItem('snspistol_grip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'grip')
-end)
-
-QBCore.Functions.CreateUseableItem('heavypistol_defaultclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
-end)
-
-QBCore.Functions.CreateUseableItem('heavypistol_extendedclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
-end)
-
-QBCore.Functions.CreateUseableItem('heavypistol_grip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'grip')
-end)
-
-QBCore.Functions.CreateUseableItem('vintagepistol_defaultclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
-end)
-
-QBCore.Functions.CreateUseableItem('vintagepistol_extendedclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
-end)
-
-QBCore.Functions.CreateUseableItem('combatpistol_defaultclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
-end)
-
-QBCore.Functions.CreateUseableItem('microsmg_extendedclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
-end)
-
-QBCore.Functions.CreateUseableItem('microsmg_scope', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scope')
-end)
-
-QBCore.Functions.CreateUseableItem('microsmg_luxuryfinish', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
-end)
-
-QBCore.Functions.CreateUseableItem('smg_defaultclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
-end)
-
-QBCore.Functions.CreateUseableItem('smg_extendedclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
-end)
-
-QBCore.Functions.CreateUseableItem('smg_suppressor', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'suppressor')
-end)
-
-QBCore.Functions.CreateUseableItem('smg_drum', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'drum')
-end)
-
-QBCore.Functions.CreateUseableItem('smg_scope', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scope')
-end)
-
-QBCore.Functions.CreateUseableItem('smg_luxuryfinish', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
-end)
-
-QBCore.Functions.CreateUseableItem('assaultsmg_defaultclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
-end)
-
-QBCore.Functions.CreateUseableItem('assaultsmg_extendedclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
-end)
-
-QBCore.Functions.CreateUseableItem('pumpshotgun_defaultclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
-end)
-
-QBCore.Functions.CreateUseableItem('sawnoffshotgun_defaultclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
-end)
-
-QBCore.Functions.CreateUseableItem('assaultsmg_luxuryfinish', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
-end)
-
-QBCore.Functions.CreateUseableItem('minismg_defaultclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
-end)
-
-QBCore.Functions.CreateUseableItem('minismg_extendedclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
-end)
-
-QBCore.Functions.CreateUseableItem('machinepistol_defaultclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
-end)
-
-QBCore.Functions.CreateUseableItem('machinepistol_extendedclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
-end)
-
-QBCore.Functions.CreateUseableItem('machinepistol_drum', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'drum')
-end)
-
-QBCore.Functions.CreateUseableItem('combatpdw_defaultclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
-end)
-
-QBCore.Functions.CreateUseableItem('combatpdw_extendedclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
-end)
-
-QBCore.Functions.CreateUseableItem('combatpistol_defaultclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
-end)
-
-QBCore.Functions.CreateUseableItem('emplauncher_defaultclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
-end)
-
-QBCore.Functions.CreateUseableItem('combatpdw_drum', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'drum')
-end)
-
-QBCore.Functions.CreateUseableItem('combatpdw_grip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'grip')
-end)
-
-QBCore.Functions.CreateUseableItem('combatpdw_scope', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scope')
-end)
-
-QBCore.Functions.CreateUseableItem('shotgun_suppressor', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'suppressor')
-end)
-
-QBCore.Functions.CreateUseableItem('pumpshotgun_luxuryfinish', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
-end)
-
-QBCore.Functions.CreateUseableItem('sawnoffshotgun_luxuryfinish', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
-end)
-
-QBCore.Functions.CreateUseableItem('sniper_luxuryfinish', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
-end)
-
-QBCore.Functions.CreateUseableItem('assaultshotgun_defaultclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
-end)
-
-QBCore.Functions.CreateUseableItem('assaultshotgun_extendedclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
-end)
-
-QBCore.Functions.CreateUseableItem('heavyshotgun_defaultclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
-end)
-
-QBCore.Functions.CreateUseableItem('heavyshotgun_extendedclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
-end)
-
-QBCore.Functions.CreateUseableItem('heavyshotgun_drum', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'drum')
-end)
-
-QBCore.Functions.CreateUseableItem('assaultrifle_defaultclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
-end)
-
-QBCore.Functions.CreateUseableItem('assaultrifle_extendedclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
-end)
-
-QBCore.Functions.CreateUseableItem('assaultrifle_drum', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'drum')
-end)
-
-QBCore.Functions.CreateUseableItem('rifle_flashlight', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'flashlight')
-end)
-
-QBCore.Functions.CreateUseableItem('rifle_grip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'grip')
-end)
-
-QBCore.Functions.CreateUseableItem('rifle_suppressor', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'suppressor')
-end)
-
-QBCore.Functions.CreateUseableItem('sniperrifle_suppressor', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'suppressor')
-end)
-
-QBCore.Functions.CreateUseableItem('assaultrifle_luxuryfinish', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
-end)
-
-QBCore.Functions.CreateUseableItem('carbinerifle_defaultclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
-end)
-
-QBCore.Functions.CreateUseableItem('carbinerifle_extendedclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
-end)
-
-QBCore.Functions.CreateUseableItem('carbinerifle_drum', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'drum')
-end)
-
-QBCore.Functions.CreateUseableItem('combatpdw_grip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'grip')
-end)
-
-QBCore.Functions.CreateUseableItem('carbinerifle_scope', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scope')
-end)
-
-QBCore.Functions.CreateUseableItem('carbinerifle_luxuryfinish', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
-end)
-
-QBCore.Functions.CreateUseableItem('advancedrifle_defaultclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
-end)
-
-QBCore.Functions.CreateUseableItem('advancedrifle_extendedclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
-end)
-
-QBCore.Functions.CreateUseableItem('advancedrifle_luxuryfinish', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
-end)
-
-QBCore.Functions.CreateUseableItem('specialcarbine_defaultclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
-end)
-
-QBCore.Functions.CreateUseableItem('specialcarbine_extendedclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
-end)
-
-QBCore.Functions.CreateUseableItem('bullpupshotgun_defaultclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
-end)
-
-QBCore.Functions.CreateUseableItem('specialcarbine_drum', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'drum')
-end)
-
-QBCore.Functions.CreateUseableItem('specialcarbine_luxuryfinish', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
-end)
-
-QBCore.Functions.CreateUseableItem('bullpuprifle_defaultclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
-end)
-
-QBCore.Functions.CreateUseableItem('bullpuprifle_extendedclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
-end)
-
-QBCore.Functions.CreateUseableItem('bullpuprifle_luxuryfinish', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
-end)
-
-QBCore.Functions.CreateUseableItem('compactrifle_defaultclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
-end)
-
-QBCore.Functions.CreateUseableItem('compactrifle_extendedclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
-end)
-
-QBCore.Functions.CreateUseableItem('compactrifle_drum', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'drum')
-end)
-
-QBCore.Functions.CreateUseableItem('gusenberg_defaultclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
-end)
-
-QBCore.Functions.CreateUseableItem('gusenberg_extendedclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
-end)
-
-QBCore.Functions.CreateUseableItem('microsmg_defaultclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
-end)
-
-QBCore.Functions.CreateUseableItem('microsmg_extendedclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
-end)
-
-QBCore.Functions.CreateUseableItem('sniperrifle_defaultclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
-end)
-
-QBCore.Functions.CreateUseableItem('sniper_scope', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scope')
-end)
-
-QBCore.Functions.CreateUseableItem('snipermax_scope', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scope')
-end)
-
-QBCore.Functions.CreateUseableItem('sniper_grip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'grip')
-end)
-
-QBCore.Functions.CreateUseableItem('heavysniper_defaultclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
-end)
-
-QBCore.Functions.CreateUseableItem('heavysniper_extendedclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
-end)
-
-QBCore.Functions.CreateUseableItem('marksmanrifle_defaultclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
-end)
-
-QBCore.Functions.CreateUseableItem('marksmanrifle_extendedclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
-end)
-
-QBCore.Functions.CreateUseableItem('marksmanrifle_scope', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scope')
-end)
-
-QBCore.Functions.CreateUseableItem('marksmanrifle_luxuryfinish', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
-end)
-
-QBCore.Functions.CreateUseableItem('snspistol_luxuryfinish', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
-end)

--- a/server/useables.lua
+++ b/server/useables.lua
@@ -1,0 +1,488 @@
+local QBCore = exports['qb-core']:GetCoreObject()
+
+-- AMMO
+QBCore.Functions.CreateUseableItem('pistol_ammo', function(source, item)
+    TriggerClientEvent('weapons:client:AddAmmo', source, 'AMMO_PISTOL', 12, item)
+end)
+
+QBCore.Functions.CreateUseableItem('rifle_ammo', function(source, item)
+    TriggerClientEvent('weapons:client:AddAmmo', source, 'AMMO_RIFLE', 30, item)
+end)
+
+QBCore.Functions.CreateUseableItem('smg_ammo', function(source, item)
+    TriggerClientEvent('weapons:client:AddAmmo', source, 'AMMO_SMG', 20, item)
+end)
+
+QBCore.Functions.CreateUseableItem('shotgun_ammo', function(source, item)
+    TriggerClientEvent('weapons:client:AddAmmo', source, 'AMMO_SHOTGUN', 10, item)
+end)
+
+QBCore.Functions.CreateUseableItem('mg_ammo', function(source, item)
+    TriggerClientEvent('weapons:client:AddAmmo', source, 'AMMO_MG', 30, item)
+end)
+
+QBCore.Functions.CreateUseableItem('snp_ammo', function(source, item)
+    TriggerClientEvent('weapons:client:AddAmmo', source, 'AMMO_SNIPER', 10, item)
+end)
+
+QBCore.Functions.CreateUseableItem('emp_ammo', function(source, item)
+    TriggerClientEvent('weapons:client:AddAmmo', source, 'AMMO_EMPLAUNCHER', 10, item)
+end)
+
+-- TINTS
+QBCore.Functions.CreateUseableItem('weapontint_black', function(source)
+    TriggerClientEvent('weapons:client:EquipTint', source, 0)
+end)
+
+QBCore.Functions.CreateUseableItem('weapontint_green', function(source)
+    TriggerClientEvent('weapons:client:EquipTint', source, 1)
+end)
+
+QBCore.Functions.CreateUseableItem('weapontint_gold', function(source)
+    TriggerClientEvent('weapons:client:EquipTint', source, 2)
+end)
+
+QBCore.Functions.CreateUseableItem('weapontint_pink', function(source)
+    TriggerClientEvent('weapons:client:EquipTint', source, 3)
+end)
+
+QBCore.Functions.CreateUseableItem('weapontint_army', function(source)
+    TriggerClientEvent('weapons:client:EquipTint', source, 4)
+end)
+
+QBCore.Functions.CreateUseableItem('weapontint_lspd', function(source)
+    TriggerClientEvent('weapons:client:EquipTint', source, 5)
+end)
+
+QBCore.Functions.CreateUseableItem('weapontint_orange', function(source)
+    TriggerClientEvent('weapons:client:EquipTint', source, 6)
+end)
+
+QBCore.Functions.CreateUseableItem('weapontint_plat', function(source)
+    TriggerClientEvent('weapons:client:EquipTint', source, 7)
+end)
+
+-- ATTACHMENTS
+QBCore.Functions.CreateUseableItem('pistol_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('pistol_extendedclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
+end)
+
+QBCore.Functions.CreateUseableItem('pistol_flashlight', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'flashlight')
+end)
+
+QBCore.Functions.CreateUseableItem('pistol_suppressor', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'suppressor')
+end)
+
+QBCore.Functions.CreateUseableItem('pistol_luxuryfinish', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
+end)
+
+QBCore.Functions.CreateUseableItem('combatpistol_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('combatpistol_extendedclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
+end)
+
+QBCore.Functions.CreateUseableItem('combatpistol_luxuryfinish', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
+end)
+
+QBCore.Functions.CreateUseableItem('appistol_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('appistol_extendedclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
+end)
+
+QBCore.Functions.CreateUseableItem('appistol_luxuryfinish', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
+end)
+
+QBCore.Functions.CreateUseableItem('pistol50_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('pistol50_extendedclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
+end)
+
+QBCore.Functions.CreateUseableItem('pistol50_luxuryfinish', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
+end)
+
+QBCore.Functions.CreateUseableItem('heavypistol_luxuryfinish', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
+end)
+
+QBCore.Functions.CreateUseableItem('revolver_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('doubleaction_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('revolver_vipvariant', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'vipvariant')
+end)
+
+QBCore.Functions.CreateUseableItem('revolver_bodyguardvariant', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'bodyguardvariant')
+end)
+
+QBCore.Functions.CreateUseableItem('snspistol_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('snspistol_extendedclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
+end)
+
+QBCore.Functions.CreateUseableItem('snspistol_grip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'grip')
+end)
+
+QBCore.Functions.CreateUseableItem('heavypistol_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('heavypistol_extendedclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
+end)
+
+QBCore.Functions.CreateUseableItem('heavypistol_grip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'grip')
+end)
+
+QBCore.Functions.CreateUseableItem('vintagepistol_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('vintagepistol_extendedclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
+end)
+
+QBCore.Functions.CreateUseableItem('combatpistol_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('microsmg_extendedclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
+end)
+
+QBCore.Functions.CreateUseableItem('microsmg_scope', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scope')
+end)
+
+QBCore.Functions.CreateUseableItem('microsmg_luxuryfinish', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
+end)
+
+QBCore.Functions.CreateUseableItem('smg_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('smg_extendedclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
+end)
+
+QBCore.Functions.CreateUseableItem('smg_suppressor', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'suppressor')
+end)
+
+QBCore.Functions.CreateUseableItem('smg_drum', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'drum')
+end)
+
+QBCore.Functions.CreateUseableItem('smg_scope', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scope')
+end)
+
+QBCore.Functions.CreateUseableItem('smg_luxuryfinish', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
+end)
+
+QBCore.Functions.CreateUseableItem('assaultsmg_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('assaultsmg_extendedclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
+end)
+
+QBCore.Functions.CreateUseableItem('pumpshotgun_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('sawnoffshotgun_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('assaultsmg_luxuryfinish', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
+end)
+
+QBCore.Functions.CreateUseableItem('minismg_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('minismg_extendedclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
+end)
+
+QBCore.Functions.CreateUseableItem('machinepistol_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('machinepistol_extendedclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
+end)
+
+QBCore.Functions.CreateUseableItem('machinepistol_drum', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'drum')
+end)
+
+QBCore.Functions.CreateUseableItem('combatpdw_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('combatpdw_extendedclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
+end)
+
+QBCore.Functions.CreateUseableItem('combatpistol_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('emplauncher_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('combatpdw_drum', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'drum')
+end)
+
+QBCore.Functions.CreateUseableItem('combatpdw_grip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'grip')
+end)
+
+QBCore.Functions.CreateUseableItem('combatpdw_scope', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scope')
+end)
+
+QBCore.Functions.CreateUseableItem('shotgun_suppressor', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'suppressor')
+end)
+
+QBCore.Functions.CreateUseableItem('pumpshotgun_luxuryfinish', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
+end)
+
+QBCore.Functions.CreateUseableItem('sawnoffshotgun_luxuryfinish', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
+end)
+
+QBCore.Functions.CreateUseableItem('sniper_luxuryfinish', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
+end)
+
+QBCore.Functions.CreateUseableItem('assaultshotgun_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('assaultshotgun_extendedclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
+end)
+
+QBCore.Functions.CreateUseableItem('heavyshotgun_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('heavyshotgun_extendedclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
+end)
+
+QBCore.Functions.CreateUseableItem('heavyshotgun_drum', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'drum')
+end)
+
+QBCore.Functions.CreateUseableItem('assaultrifle_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('assaultrifle_extendedclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
+end)
+
+QBCore.Functions.CreateUseableItem('assaultrifle_drum', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'drum')
+end)
+
+QBCore.Functions.CreateUseableItem('rifle_flashlight', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'flashlight')
+end)
+
+QBCore.Functions.CreateUseableItem('rifle_grip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'grip')
+end)
+
+QBCore.Functions.CreateUseableItem('rifle_suppressor', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'suppressor')
+end)
+
+QBCore.Functions.CreateUseableItem('sniperrifle_suppressor', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'suppressor')
+end)
+
+QBCore.Functions.CreateUseableItem('assaultrifle_luxuryfinish', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
+end)
+
+QBCore.Functions.CreateUseableItem('carbinerifle_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('carbinerifle_extendedclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
+end)
+
+QBCore.Functions.CreateUseableItem('carbinerifle_drum', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'drum')
+end)
+
+QBCore.Functions.CreateUseableItem('combatpdw_grip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'grip')
+end)
+
+QBCore.Functions.CreateUseableItem('carbinerifle_scope', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scope')
+end)
+
+QBCore.Functions.CreateUseableItem('carbinerifle_luxuryfinish', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
+end)
+
+QBCore.Functions.CreateUseableItem('advancedrifle_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('advancedrifle_extendedclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
+end)
+
+QBCore.Functions.CreateUseableItem('advancedrifle_luxuryfinish', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
+end)
+
+QBCore.Functions.CreateUseableItem('specialcarbine_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('specialcarbine_extendedclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
+end)
+
+QBCore.Functions.CreateUseableItem('bullpupshotgun_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('specialcarbine_drum', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'drum')
+end)
+
+QBCore.Functions.CreateUseableItem('specialcarbine_luxuryfinish', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
+end)
+
+QBCore.Functions.CreateUseableItem('bullpuprifle_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('bullpuprifle_extendedclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
+end)
+
+QBCore.Functions.CreateUseableItem('bullpuprifle_luxuryfinish', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
+end)
+
+QBCore.Functions.CreateUseableItem('compactrifle_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('compactrifle_extendedclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
+end)
+
+QBCore.Functions.CreateUseableItem('compactrifle_drum', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'drum')
+end)
+
+QBCore.Functions.CreateUseableItem('gusenberg_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('gusenberg_extendedclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
+end)
+
+QBCore.Functions.CreateUseableItem('microsmg_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('microsmg_extendedclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
+end)
+
+QBCore.Functions.CreateUseableItem('sniperrifle_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('sniper_scope', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scope')
+end)
+
+QBCore.Functions.CreateUseableItem('snipermax_scope', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scope')
+end)
+
+QBCore.Functions.CreateUseableItem('sniper_grip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'grip')
+end)
+
+QBCore.Functions.CreateUseableItem('heavysniper_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('heavysniper_extendedclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
+end)
+
+QBCore.Functions.CreateUseableItem('marksmanrifle_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('marksmanrifle_extendedclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
+end)
+
+QBCore.Functions.CreateUseableItem('marksmanrifle_scope', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scope')
+end)
+
+QBCore.Functions.CreateUseableItem('marksmanrifle_luxuryfinish', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
+end)
+
+QBCore.Functions.CreateUseableItem('snspistol_luxuryfinish', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
+end)


### PR DESCRIPTION
Description: This adds full support for qb-target and removes the old, archaic "press E" system. The list of updates follow:
* Re-coded config to support more customization. 
* Use of Ped or Boxzone target, 
* Specific repair point weapon costs, 
* Optional configuring for JOB/GANG/CITIZEN locking
* Table timeout (that allows any person to collect the weapon, not delete it to the void)

- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? **[yes]** (fresh qbcore (full) install as of 11/23/2022)
- Does your code fit the style guidelines? **[yes]**
- Does your PR fit the contribution guidelines? **[yes]**
