### PR TITLE
[FIX ] Elimination of error in practical use (Inaccuracy of item names).

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -145,7 +145,7 @@ QBCore.Functions.CreateCallback('prison:server:checkThrowable', function(source,
     local throwable = false
     for _,v in pairs(Config.Throwables) do
         if QBCore.Shared.Weapons[weapon].name == 'weapon_'..v then
-            Player.Functions.RemoveItem(v, 1)
+            Player.Functions.RemoveItem('weapon_'..v, 1)
             throwable = true
             break
         end


### PR DESCRIPTION
According to QBCore Shared Items, this fix is required for this to work properly, it has been tested in-game. Another solution to the error is to modify the config, but this is a more practical solution.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest) = 

> Yes

- Does your code fit the style guidelines? [yes/no] = 

> Yes

- Does your PR fit the contribution guidelines? [yes/no] =

> Yes
