### PR TITLE
Fix for Weapon Tints

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -57,6 +57,7 @@ RegisterNetEvent('weapons:client:EquipTint', function(tint)
     local player = PlayerPedId()
     local weapon = GetSelectedPedWeapon(player)
     SetPedWeaponTintIndex(player, weapon, tint)
+    TriggerServerEvent("weapons:server:ApplyTint", CurrentWeaponData, tint)
 end)
 
 RegisterNetEvent('weapons:client:SetCurrentWeapon', function(data, bool)

--- a/server/main.lua
+++ b/server/main.lua
@@ -224,6 +224,14 @@ RegisterNetEvent('weapons:server:UpdateWeaponQuality', function(data, RepeatAmou
     Player.Functions.SetInventory(Player.PlayerData.items, true)
 end)
 
+RegisterNetEvent('weapons:server:ApplyTint', function(data, tint)
+    local src = source
+    local Player = QBCore.Functions.GetPlayer(src)
+    local WeaponSlot = Player.PlayerData.items[data.slot]
+    WeaponSlot.info.tint = tint
+    Player.Functions.SetInventory(Player.PlayerData.items, true)
+end)
+
 RegisterNetEvent("weapons:server:EquipAttachment", function(ItemData, CurrentWeaponData, AttachmentData)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)


### PR DESCRIPTION
Changes made in qb-weapon allows the tint number to be saved in the database under the weapon items info in player inventory.

Changes made to client/main.lua:
- Updated weapons:client:EquiptTint to trigger Server Event ApplyTint

Changes made to server/main.lua:
- Created Server Event ApplyTint

**Describe Pull request**
First, make sure you've read and are following the contribution guidelines and style guide and your code reflects that.
Write up a clear and concise description of what your pull request adds or fixes and if it's an added feature explain why you think it should be included in the core.

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest)
- Does your code fit the style guidelines? [yes/no]
- Does your PR fit the contribution guidelines? [yes/no]
