### PR TITLE
Add delay for throwable weapons

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -163,7 +163,12 @@ CreateThread(function()
                                 if result or GetAmmoInPedWeapon(ped, weapon) <= 0 then return end
                                 MultiplierAmount += 1
                             end, weapon)
-                            Wait(200)
+
+                            if QBCore.Shared.Weapons[weapon].weapontype == 'Throwable' then
+                                Wait(1000)
+                            else
+                                Wait(200)
+                            end
                         end
                     else
                         if weapon ~= `WEAPON_UNARMED` then

--- a/server/main.lua
+++ b/server/main.lua
@@ -171,20 +171,26 @@ RegisterNetEvent("weapons:server:TakeBackWeapon", function(k)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
     local itemdata = Config.WeaponRepairPoints[k].RepairingData.WeaponData
-    itemdata.info.quality = 100
-    Player.Functions.AddItem(itemdata.name, 1, false, itemdata.info)
-    TriggerClientEvent('inventory:client:ItemBox', src, QBCore.Shared.Items[itemdata.name], "add")
-    Config.WeaponRepairPoints[k].IsRepairing = false
-    Config.WeaponRepairPoints[k].RepairingData = {}
-    TriggerClientEvent('weapons:client:SyncRepairShops', -1, Config.WeaponRepairPoints[k], k)
+
+    if Player then
+        itemdata.info.quality = 100
+        Player.Functions.AddItem(itemdata.name, 1, false, itemdata.info)
+        TriggerClientEvent('inventory:client:ItemBox', src, QBCore.Shared.Items[itemdata.name], "add")
+        Config.WeaponRepairPoints[k].IsRepairing = false
+        Config.WeaponRepairPoints[k].RepairingData = {}
+        TriggerClientEvent('weapons:client:SyncRepairShops', -1, Config.WeaponRepairPoints[k], k)
+    end
 end)
 
 RegisterNetEvent("weapons:server:SetWeaponQuality", function(data, hp)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
     local WeaponSlot = Player.PlayerData.items[data.slot]
-    WeaponSlot.info.quality = hp
-    Player.Functions.SetInventory(Player.PlayerData.items, true)
+
+    if Player then
+        WeaponSlot.info.quality = hp
+        Player.Functions.SetInventory(Player.PlayerData.items, true)
+    end
 end)
 
 RegisterNetEvent('weapons:server:UpdateWeaponQuality', function(data, RepeatAmount)


### PR DESCRIPTION
**Describe Pull request**
Every time a player throw a grenade, it might be a chance it will take 2 items of grenade if you have more than 1 item of grenade in your inventory

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
