### PR TITLE
Weapon/Tint Rework

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -7,6 +7,19 @@ Config.DurabilityBlockedWeapons = {
     "weapon_nightstick",
     "weapon_flashlight",
     "weapon_unarmed",
+	"weapon_knuckle",
+	"weapon_knife",
+	"weapon_switchblade",
+	"weapon_dagger",
+	"weapon_crowbar",
+	"weapon_hammer",
+	"weapon_hatchet",
+	"weapon_machete",
+	"weapon_wrench",
+	"weapon_battleaxe",
+	"weapon_poolcue",
+	"weapon_stone_hatchet",
+	"weapon_candycane",
 }
 
 Config.Throwables = {
@@ -24,13 +37,13 @@ Config.Throwables = {
 
 Config.DurabilityMultiplier = {
     -- Melee
-    -- ['weapon_unarmed'] 				 = 0.15,
+    -- ['weapon_unarmed'] 			 = 0.15,
     ['weapon_dagger']                = 0.15,
     ['weapon_bat']                   = 0.15,
     ['weapon_bottle']                = 0.15,
     ['weapon_crowbar']               = 0.15,
     ['weapon_candycane']             = 0.15,
-    -- ['weapon_flashlight'] 			 = 0.15,
+    -- ['weapon_flashlight'] 		 = 0.15,
     ['weapon_golfclub']              = 0.15,
     ['weapon_hammer']                = 0.15,
     ['weapon_hatchet']               = 0.15,
@@ -38,15 +51,10 @@ Config.DurabilityMultiplier = {
     ['weapon_knife']                 = 0.15,
     ['weapon_machete']               = 0.15,
     ['weapon_switchblade']           = 0.15,
-    -- ['weapon_nightstick'] 			 = 0.15,
+    -- ['weapon_nightstick'] 		 = 0.15,
     ['weapon_wrench']                = 0.15,
     ['weapon_battleaxe']             = 0.15,
     ['weapon_poolcue']               = 0.15,
-    ['weapon_briefcase']             = 0.15,
-    ['weapon_briefcase_02']          = 0.15,
-    ['weapon_garbagebag']            = 0.15,
-    ['weapon_handcuffs']             = 0.15,
-    ['weapon_bread']                 = 0.15,
     ['weapon_stone_hatchet']         = 0.15,
 
     -- Handguns
@@ -54,8 +62,8 @@ Config.DurabilityMultiplier = {
     ['weapon_pistol_mk2']            = 0.15,
     ['weapon_combatpistol']          = 0.15,
     ['weapon_appistol']              = 0.15,
-    -- ['weapon_stungun'] 				 = 0.15,
-    -- ['weapon_stungun_mp'] 				 = 0.15,
+    -- ['weapon_stungun'] 			 = 0.15,
+    -- ['weapon_stungun_mp'] 		 = 0.15,
     ['weapon_pistol50']              = 0.15,
     ['weapon_snspistol']             = 0.15,
     ['weapon_heavypistol']           = 0.15,
@@ -81,7 +89,9 @@ Config.DurabilityMultiplier = {
     ['weapon_machinepistol']         = 0.15,
     ['weapon_minismg']               = 0.15,
     ['weapon_raycarbine']            = 0.15,
-
+	['weapon_gusenberg']             = 0.15,
+	['weapon_tecpistol']             = 0.15,
+	
     -- Shotguns
     ['weapon_pumpshotgun']           = 0.15,
     ['weapon_sawnoffshotgun']        = 0.15,
@@ -107,20 +117,21 @@ Config.DurabilityMultiplier = {
     ['weapon_bullpuprifle_mk2']      = 0.15,
     ['weapon_militaryrifle']         = 0.15,
     ['weapon_heavyrifle']            = 0.15,
+	['weapon_tacticalrifle']         = 0.15,
 
-    -- Light Machine Guns
+    -- Machine Guns
     ['weapon_mg']                    = 0.15,
     ['weapon_combatmg']              = 0.15,
-    ['weapon_gusenberg']             = 0.15,
     ['weapon_combatmg_mk2']          = 0.15,
+	['weapon_raycarbine']            = 0.15,
 
     -- Sniper Rifles
     ['weapon_sniperrifle']           = 0.15,
     ['weapon_heavysniper']           = 0.15,
     ['weapon_marksmanrifle']         = 0.15,
-    ['weapon_remotesniper']          = 0.15,
     ['weapon_heavysniper_mk2']       = 0.15,
     ['weapon_marksmanrifle_mk2']     = 0.15,
+	['weapon_precisionrifle']		 = 0.15,
 
     -- Heavy Weapons
     ['weapon_rpg']                   = 0.15,
@@ -163,17 +174,176 @@ Config.WeaponRepairPoints = {
 }
 
 Config.WeaponRepairCosts = {
-    ["pistol"] = 1000,
+    ["melee"] = 250,
+	["pistol"] = 1000,
     ["smg"] = 3000,
     ["mg"] = 4000,
     ["rifle"] = 5000,
     ["sniper"] = 7000,
-    ["shotgun"] = 6000
+    ["shotgun"] = 6000,
+	["heavy"] = 9000
 }
 
 WeaponAttachments = {
-    -- PISTOLS
-    ['WEAPON_PISTOL'] = {
+    -- MELEE
+	['WEAPON_BAT'] = {
+        ['wepskin1'] = {
+            component = 'COMPONENT_BAT_VARMOD_XM3',
+            item = 'bat_skin1',
+        },
+		['wepskin2'] = {
+            component = 'COMPONENT_BAT_VARMOD_XM3_01',
+            item = 'bat_skin2',
+        },
+		['wepskin3'] = {
+            component = 'COMPONENT_BAT_VARMOD_XM3_02',
+            item = 'bat_skin3',
+        },
+		['wepskin4'] = {
+            component = 'COMPONENT_BAT_VARMOD_XM3_03',
+            item = 'bat_skin4',
+        },
+		['wepskin5'] = {
+            component = 'COMPONENT_BAT_VARMOD_XM3_04',
+            item = 'bat_skin5',
+        },
+		['wepskin6'] = {
+            component = 'COMPONENT_BAT_VARMOD_XM3_05',
+            item = 'bat_skin6',
+        },
+		['wepskin7'] = {
+            component = 'COMPONENT_BAT_VARMOD_XM3_06',
+            item = 'bat_skin7',
+        },
+		['wepskin8'] = {
+            component = 'COMPONENT_BAT_VARMOD_XM3_07',
+            item = 'bat_skin8',
+        },
+		['wepskin9'] = {
+            component = 'COMPONENT_BAT_VARMOD_XM3_08',
+            item = 'bat_skin9',
+        },
+		['wepskin10'] = {
+            component = 'COMPONENT_BAT_VARMOD_XM3_09',
+            item = 'bat_skin10',
+        },
+    },
+	['WEAPON_KNUCKLE'] = {
+        ['wepskin1'] = {
+            component = 'COMPONENT_KNUCKLE_VARMOD_BALLAS',
+            item = 'knuckle_skin1',
+        },
+		['wepskin2'] = {
+            component = 'COMPONENT_KNUCKLE_VARMOD_BASE',
+            item = 'knuckle_skin2',
+        },
+		['wepskin3'] = {
+            component = 'COMPONENT_KNUCKLE_VARMOD_DIAMOND',
+            item = 'knuckle_skin3',
+        },
+		['wepskin4'] = {
+            component = 'COMPONENT_KNUCKLE_VARMOD_DOLLAR',
+            item = 'knuckle_skin4',
+        },
+		['wepskin5'] = {
+            component = 'COMPONENT_KNUCKLE_VARMOD_HATE',
+            item = 'knuckle_skin5',
+        },
+		['wepskin6'] = {
+            component = 'COMPONENT_KNUCKLE_VARMOD_KING',
+            item = 'knuckle_skin6',
+        },
+		['wepskin7'] = {
+            component = 'COMPONENT_KNUCKLE_VARMOD_LOVE',
+            item = 'knuckle_skin7',
+        },
+		['wepskin8'] = {
+            component = 'COMPONENT_KNUCKLE_VARMOD_PIMP',
+            item = 'knuckle_skin8',
+        },
+		['wepskin9'] = {
+            component = 'COMPONENT_KNUCKLE_VARMOD_PLAYER',
+            item = 'knuckle_skin9',
+        },
+		['wepskin10'] = {
+            component = 'COMPONENT_KNUCKLE_VARMOD_VAGOS',
+            item = 'knuckle_skin10',
+        },
+    },
+	['WEAPON_KNIFE'] = {
+        ['wepskin1'] = {
+            component = 'COMPONENT_KNIFE_VARMOD_XM3',
+            item = 'knife_skin1',
+        },
+		['wepskin2'] = {
+            component = 'COMPONENT_KNIFE_VARMOD_XM3_01',
+            item = 'knife_skin2',
+        },
+		['wepskin3'] = {
+            component = 'COMPONENT_KNIFE_VARMOD_XM3_02',
+            item = 'knife_skin3',
+        },
+		['wepskin4'] = {
+            component = 'COMPONENT_KNIFE_VARMOD_XM3_03',
+            item = 'knife_skin4',
+        },
+		['wepskin5'] = {
+            component = 'COMPONENT_KNIFE_VARMOD_XM3_04',
+            item = 'knife_skin5',
+        },
+		['wepskin6'] = {
+            component = 'COMPONENT_KNIFE_VARMOD_XM3_05',
+            item = 'knife_skin6',
+        },
+		['wepskin7'] = {
+            component = 'COMPONENT_KNIFE_VARMOD_XM3_06',
+            item = 'knife_skin7',
+        },
+		['wepskin8'] = {
+            component = 'COMPONENT_KNIFE_VARMOD_XM3_07',
+            item = 'knife_skin8',
+        },
+		['wepskin9'] = {
+            component = 'COMPONENT_KNIFE_VARMOD_XM3_08',
+            item = 'knife_skin9',
+        },
+		['wepskin10'] = {
+            component = 'COMPONENT_KNIFE_VARMOD_XM3_09',
+            item = 'knife_skin10',
+        },
+    },
+	['WEAPON_SWITCHBLADE'] = {
+        ['wepskin1'] = {
+            component = 'COMPONENT_SWITCHBLADE_VARMOD_BASE',
+            item = 'switchblade_skin1',
+        },
+		['wepskin2'] = {
+            component = 'COMPONENT_SWITCHBLADE_VARMOD_VAR1',
+            item = 'switchblade_skin2',
+        },
+		['wepskin3'] = {
+            component = 'COMPONENT_SWITCHBLADE_VARMOD_VAR2',
+            item = 'switchblade_skin3',
+        },
+    },
+	-- ['WEAPON_UNARMED'] = {}, -- Placeholder, No usable components at this time
+	-- ['WEAPON_DAGGER'] = {}, -- Placeholder, No usable components at this time
+	-- ['WEAPON_BOTTLE'] = {}, -- Placeholder, No usable components at this time
+	-- ['WEAPON_CROWBAR'] = {}, -- Placeholder, No usable components at this time
+	-- ['WEAPON_FLASHLIGHT'] = {}, -- Placeholder, No usable components at this time
+	-- ['WEAPON_GOLFCLUB'] = {}, -- Placeholder, No usable components at this time
+	-- ['WEAPON_HAMMER'] = {}, -- Placeholder, No usable components at this time
+	-- ['WEAPON_HATCHET'] = {}, -- Placeholder, No usable components at this time
+	-- ['WEAPON_MACHETE'] = {}, -- Placeholder, No usable components at this time
+	-- ['WEAPON_NIGHTSTICK'] = {}, -- Placeholder, No usable components at this time
+	-- ['WEAPON_WRENCH'] = {}, -- Placeholder, No usable components at this time
+	-- ['WEAPON_BATTLEAXE'] = {}, -- Placeholder, No usable components at this time
+	-- ['WEAPON_POOLCUE'] = {}, -- Placeholder, No usable components at this time
+	-- ['WEAPON_STONE_HATCHET'] = {}, -- Placeholder, No usable components at this time
+	-- ['WEAPON_CANDYCANE'] = {}, -- Placeholder, No usable components at this time
+	
+	-- PISTOLS
+	['WEAPON_PISTOL'] = {
         ['defaultclip'] = {
             component = 'COMPONENT_PISTOL_CLIP_01',
             item = 'pistol_defaultclip',
@@ -186,18 +356,18 @@ WeaponAttachments = {
         },
         ['flashlight'] = {
             component = 'COMPONENT_AT_PI_FLSH',
-            item = 'pistol_flashlight',
+            item = 'wep_flashlight',
         },
         ['suppressor'] = {
             component = 'COMPONENT_AT_PI_SUPP_02',
             item = 'pistol_suppressor',
         },
-        ['luxuryfinish'] = {
+        ['luxuryfinish1'] = {
             component = 'COMPONENT_PISTOL_VARMOD_LUXE',
-            item = 'pistol_luxuryfinish',
+            item = 'pistol_luxuryfinish1',
         },
     },
-    ['WEAPON_COMBATPISTOL'] = {
+	['WEAPON_COMBATPISTOL'] = {
         ['defaultclip'] = {
             component = 'COMPONENT_COMBATPISTOL_CLIP_01',
             item = 'combatpistol_defaultclip',
@@ -210,18 +380,18 @@ WeaponAttachments = {
         },
         ['flashlight'] = {
             component = 'COMPONENT_AT_PI_FLSH',
-            item = 'pistol_flashlight',
+            item = 'wep_flashlight',
         },
         ['suppressor'] = {
             component = 'COMPONENT_AT_PI_SUPP',
             item = 'pistol_suppressor',
         },
-        ['luxuryfinish'] = {
+        ['luxuryfinish1'] = {
             component = 'COMPONENT_COMBATPISTOL_VARMOD_LOWRIDER',
-            item = 'combatpistol_luxuryfinish',
+            item = 'combatpistol_luxuryfinish1',
         },
     },
-    ['WEAPON_APPISTOL'] = {
+	['WEAPON_APPISTOL'] = {
         ['defaultclip'] = {
             component = 'COMPONENT_APPISTOL_CLIP_01',
             item = 'appistol_defaultclip',
@@ -234,18 +404,22 @@ WeaponAttachments = {
         },
         ['flashlight'] = {
             component = 'COMPONENT_AT_PI_FLSH',
-            item = 'pistol_flashlight',
+            item = 'wep_flashlight',
         },
         ['suppressor'] = {
             component = 'COMPONENT_AT_PI_SUPP',
             item = 'pistol_suppressor',
         },
-        ['luxuryfinish'] = {
+        ['luxuryfinish1'] = {
             component = 'COMPONENT_APPISTOL_VARMOD_LUXE',
-            item = 'appistol_luxuryfinish',
+            item = 'appistol_luxuryfinish1',
+        },
+		['luxuryfinish2'] = {
+            component = 'COMPONENT_APPISTOL_VARMOD_LUXE',
+            item = 'appistol_luxuryfinish2',
         },
     },
-    ['WEAPON_PISTOL50'] = {
+	['WEAPON_PISTOL50'] = {
         ['defaultclip'] = {
             component = 'COMPONENT_PISTOL50_CLIP_01',
             item = 'pistol50_defaultclip',
@@ -258,34 +432,18 @@ WeaponAttachments = {
         },
         ['flashlight'] = {
             component = 'COMPONENT_AT_PI_FLSH',
-            item = 'pistol_flashlight',
+            item = 'wep_flashlight',
         },
         ['suppressor'] = {
             component = 'COMPONENT_AT_AR_SUPP_02',
             item = 'pistol_suppressor',
         },
-        ['luxuryfinish'] = {
+        ['luxuryfinish1'] = {
             component = 'COMPONENT_PISTOL50_VARMOD_LUXE',
-            item = 'pistol50_luxuryfinish',
+            item = 'pistol50_luxuryfinish1',
         },
     },
-    ['WEAPON_REVOLVER'] = {
-        ['defaultclip'] = {
-            component = 'COMPONENT_REVOLVER_CLIP_01',
-            item = 'revolver_defaultclip',
-        },
-        ['vipvariant'] = {
-            component = 'COMPONENT_REVOLVER_VARMOD_GOON',
-            item = 'revolver_vipvariant',
-            type = 'skin',
-        },
-        ['bodyguardvariant'] = {
-            component = 'COMPONENT_REVOLVER_VARMOD_BOSS',
-            item = 'revolver_bodyguardvariant',
-            type = 'skin',
-        },
-    },
-    ['WEAPON_SNSPISTOL'] = {
+	['WEAPON_SNSPISTOL'] = {
         ['defaultclip'] = {
             component = 'COMPONENT_SNSPISTOL_CLIP_01',
             item = 'snspistol_defaultclip',
@@ -296,12 +454,13 @@ WeaponAttachments = {
             item = 'snspistol_extendedclip',
             type = 'clip',
         },
-        ['grip'] = {
+        ['luxuryfinish1'] = {
             component = 'COMPONENT_SNSPISTOL_VARMOD_LOWRIDER',
-            item = 'snspistol_grip',
+            item = 'snspistol_luxuryfinish1',
+            type = 'skin',
         },
     },
-    ['WEAPON_HEAVYPISTOL'] = {
+	['WEAPON_HEAVYPISTOL'] = {
         ['defaultclip'] = {
             component = 'COMPONENT_HEAVYPISTOL_CLIP_01',
             item = 'heavypistol_defaultclip',
@@ -314,18 +473,19 @@ WeaponAttachments = {
         },
         ['flashlight'] = {
             component = 'COMPONENT_AT_PI_FLSH',
-            item = 'pistol_flashlight',
+            item = 'wep_flashlight',
         },
         ['suppressor'] = {
             component = 'COMPONENT_AT_PI_SUPP',
             item = 'pistol_suppressor',
         },
-        ['grip'] = {
-            component = 'COMPONENT_HEAVYPISTOL_VARMOD_LUXE',
-            item = 'heavypistol_grip',
+        ['luxuryfinish1'] = {
+            component = 'COMPONENT_SNSPISTOL_VARMOD_LOWRIDER',
+            item = 'heavypistol_luxuryfinish1',
+            type = 'skin',
         },
     },
-    ['WEAPON_VINTAGEPISTOL'] = {
+	['WEAPON_VINTAGEPISTOL'] = {
         ['defaultclip'] = {
             component = 'COMPONENT_VINTAGEPISTOL_CLIP_01',
             item = 'vintagepistol_defaultclip',
@@ -342,8 +502,350 @@ WeaponAttachments = {
             type = 'silencer',
         },
     },
-    -- SMG'S
-    ['WEAPON_MICROSMG'] = {
+	['WEAPON_REVOLVER'] = {
+        ['luxuryfinish1'] = {
+            component = 'COMPONENT_REVOLVER_VARMOD_GOON',
+            item = 'revolver_luxuryfinish1',
+            type = 'skin',
+        },
+        ['luxuryfinish2'] = {
+            component = 'COMPONENT_REVOLVER_VARMOD_BOSS',
+            item = 'revolver_luxuryfinish2',
+            type = 'skin',
+        },
+    },
+	['WEAPON_PISTOL_MK2'] = {
+        ['defaultclip'] = {
+            component = 'COMPONENT_PISTOL_MK2_CLIP_01',
+            item = 'pistol_mk2_defaultclip',
+            type = 'clip',
+        },
+        ['extendedclip'] = {
+            component = 'COMPONENT_PISTOL_MK2_CLIP_02',
+            item = 'pistol_mk2_extendedclip',
+            type = 'clip',
+        },
+        ['flashlight'] = {
+            component = 'COMPONENT_AT_PI_FLSH_02',
+            item = 'wep_flashlight',
+        },
+        ['suppressor'] = {
+            component = 'COMPONENT_AT_PI_SUPP_02',
+            item = 'pistol_suppressor',
+        },
+		['compensator'] = {
+            component = 'COMPONENT_AT_PI_COMP',
+            item = 'wep_compensator',
+        },
+        ['luxuryfinish1'] = {
+            component = 'COMPONENT_PISTOL_MK2_VARMOD_XM3',
+            item = 'pistol_mk2_luxuryfinish1',
+        },
+		['luxuryfinish2'] = {
+            component = 'COMPONENT_PISTOL_MK2_VARMOD_XM3_SLIDE',
+            item = 'pistol_mk2_luxuryfinish2',
+        },
+		['luxuryfinish3'] = {
+            component = 'COMPONENT_PISTOL_MK2_CAMO',
+            item = 'pistol_mk2_luxuryfinish3',
+        },
+		['luxuryfinish4'] = {
+            component = 'COMPONENT_PISTOL_MK2_CAMO_02',
+            item = 'pistol_mk2_luxuryfinish4',
+        },
+		['luxuryfinish5'] = {
+            component = 'COMPONENT_PISTOL_MK2_CAMO_03',
+            item = 'pistol_mk2_luxuryfinish5',
+        },
+		['luxuryfinish6'] = {
+            component = 'COMPONENT_PISTOL_MK2_CAMO_04',
+            item = 'pistol_mk2_luxuryfinish6',
+        },
+		['luxuryfinish7'] = {
+            component = 'COMPONENT_PISTOL_MK2_CAMO_05',
+            item = 'pistol_mk2_luxuryfinish7',
+        },
+		['luxuryfinish8'] = {
+            component = 'COMPONENT_PISTOL_MK2_CAMO_06',
+            item = 'pistol_mk2_luxuryfinish8',
+        },
+		['luxuryfinish9'] = {
+            component = 'COMPONENT_PISTOL_MK2_CAMO_07',
+            item = 'pistol_mk2_luxuryfinish9',
+        },
+		['luxuryfinish10'] = {
+            component = 'COMPONENT_PISTOL_MK2_CAMO_08',
+            item = 'pistol_mk2_luxuryfinish10',
+        },
+		['luxuryfinish11'] = {
+            component = 'COMPONENT_PISTOL_MK2_CAMO_09',
+            item = 'pistol_mk2_luxuryfinish11',
+        },
+		['luxuryfinish12'] = {
+            component = 'COMPONENT_PISTOL_MK2_CAMO_10',
+            item = 'pistol_mk2_luxuryfinish12',
+        },
+		['luxuryfinish13'] = {
+            component = 'COMPONENT_PISTOL_MK2_CAMO_IND_01',
+            item = 'pistol_mk2_luxuryfinish13',
+        },
+		['luxuryfinish14'] = {
+            component = 'COMPONENT_PISTOL_MK2_CAMO_SLIDE',
+            item = 'pistol_mk2_luxuryfinish14',
+        },
+		['luxuryfinish15'] = {
+            component = 'COMPONENT_PISTOL_MK2_CAMO_02_SLIDE',
+            item = 'pistol_mk2_luxuryfinish15',
+        },
+		['luxuryfinish16'] = {
+            component = 'COMPONENT_PISTOL_MK2_CAMO_03_SLIDE',
+            item = 'pistol_mk2_luxuryfinish16',
+        },
+		['luxuryfinish17'] = {
+            component = 'COMPONENT_PISTOL_MK2_CAMO_04_SLIDE',
+            item = 'pistol_mk2_luxuryfinish17',
+        },
+		['luxuryfinish18'] = {
+            component = 'COMPONENT_PISTOL_MK2_CAMO_05_SLIDE',
+            item = 'pistol_mk2_luxuryfinish18',
+        },
+		['luxuryfinish19'] = {
+            component = 'COMPONENT_PISTOL_MK2_CAMO_06_SLIDE',
+            item = 'pistol_mk2_luxuryfinish19',
+        },
+		['luxuryfinish20'] = {
+            component = 'COMPONENT_PISTOL_MK2_CAMO_07_SLIDE',
+            item = 'pistol_mk2_luxuryfinish20',
+        },
+		['luxuryfinish21'] = {
+            component = 'COMPONENT_PISTOL_MK2_CAMO_08_SLIDE',
+            item = 'pistol_mk2_luxuryfinish21',
+        },
+		['luxuryfinish22'] = {
+            component = 'COMPONENT_PISTOL_MK2_CAMO_09_SLIDE',
+            item = 'pistol_mk2_luxuryfinish22',
+        },
+		['luxuryfinish23'] = {
+            component = 'COMPONENT_PISTOL_MK2_CAMO_10_SLIDE',
+            item = 'pistol_mk2_luxuryfinish23',
+        },
+		['luxuryfinish24'] = {
+            component = 'COMPONENT_PISTOL_MK2_CAMO_IND_01_SLIDE',
+            item = 'pistol_mk2_luxuryfinish24',
+        },
+    },
+	['WEAPON_SNSPISTOL_MK2'] = {
+        ['defaultclip'] = {
+            component = 'COMPONENT_SNSPISTOL_MK2_CLIP_01',
+            item = 'snspistol_defaultclip',
+            type = 'clip',
+        },
+        ['extendedclip'] = {
+            component = 'COMPONENT_SNSPISTOL_MK2_CLIP_02',
+            item = 'snspistol_extendedclip',
+            type = 'clip',
+        },
+        ['flashlight'] = {
+            component = 'COMPONENT_AT_PI_FLSH_03',
+            item = 'wep_flashlight',
+        },
+		['compensator'] = {
+            component = 'COMPONENT_AT_PI_COMP_02',
+            item = 'wep_compensator',
+        },
+        ['scope'] = {
+            component = 'COMPONENT_AT_PI_RAIL_02',
+            item = 'snspistol_mk2_scope',
+        },
+		['luxuryfinish1'] = {
+            component = 'COMPONENT_SNSPISTOL_MK2_CAMO',
+            item = 'snspistol_mk2_luxuryfinish1',
+        },
+		['luxuryfinish2'] = {
+            component = 'COMPONENT_SNSPISTOL_MK2_CAMO_02',
+            item = 'snspistol_mk2_luxuryfinish2',
+        },
+		['luxuryfinish3'] = {
+            component = 'COMPONENT_SNSPISTOL_MK2_CAMO_03',
+            item = 'snspistol_mk2_luxuryfinish3',
+        },
+		['luxuryfinish4'] = {
+            component = 'COMPONENT_SNSPISTOL_MK2_CAMO_04',
+            item = 'snspistol_mk2_luxuryfinish4',
+        },
+		['luxuryfinish5'] = {
+            component = 'COMPONENT_SNSPISTOL_MK2_CAMO_05',
+            item = 'snspistol_mk2_luxuryfinish5',
+        },
+		['luxuryfinish6'] = {
+            component = 'COMPONENT_SNSPISTOL_MK2_CAMO_06',
+            item = 'snspistol_mk2_luxuryfinish6',
+        },
+		['luxuryfinish7'] = {
+            component = 'COMPONENT_SNSPISTOL_MK2_CAMO_07',
+            item = 'snspistol_mk2_luxuryfinish7',
+        },
+		['luxuryfinish8'] = {
+            component = 'COMPONENT_SNSPISTOL_MK2_CAMO_08',
+            item = 'snspistol_mk2_luxuryfinish8',
+        },
+		['luxuryfinish9'] = {
+            component = 'COMPONENT_SNSPISTOL_MK2_CAMO_09',
+            item = 'snspistol_mk2_luxuryfinish9',
+        },
+		['luxuryfinish10'] = {
+            component = 'COMPONENT_SNSPISTOL_MK2_CAMO_10',
+            item = 'snspistol_mk2_luxuryfinish10',
+        },
+		['luxuryfinish11'] = {
+            component = 'COMPONENT_SNSPISTOL_MK2_CAMO_IND_01',
+            item = 'snspistol_mk2_luxuryfinish11',
+        },
+		['luxuryfinish12'] = {
+            component = 'COMPONENT_SNSPISTOL_MK2_CAMO_SLIDE',
+            item = 'snspistol_mk2_luxuryfinish12',
+        },
+		['luxuryfinish13'] = {
+            component = 'COMPONENT_SNSPISTOL_MK2_CAMO_02_SLIDE',
+            item = 'snspistol_mk2_luxuryfinish13',
+        },
+		['luxuryfinish14'] = {
+            component = 'COMPONENT_SNSPISTOL_MK2_CAMO_03_SLIDE',
+            item = 'snspistol_mk2_luxuryfinish14',
+        },
+		['luxuryfinish15'] = {
+            component = 'COMPONENT_SNSPISTOL_MK2_CAMO_04_SLIDE',
+            item = 'snspistol_mk2_luxuryfinish15',
+        },
+		['luxuryfinish16'] = {
+            component = 'COMPONENT_SNSPISTOL_MK2_CAMO_05_SLIDE',
+            item = 'snspistol_mk2_luxuryfinish16',
+        },
+		['luxuryfinish17'] = {
+            component = 'COMPONENT_SNSPISTOL_MK2_CAMO_06_SLIDE',
+            item = 'snspistol_mk2_luxuryfinish17',
+        },
+		['luxuryfinish18'] = {
+            component = 'COMPONENT_SNSPISTOL_MK2_CAMO_07_SLIDE',
+            item = 'snspistol_mk2_luxuryfinish18',
+        },
+		['luxuryfinish19'] = {
+            component = 'COMPONENT_SNSPISTOL_MK2_CAMO_08_SLIDE',
+            item = 'snspistol_mk2_luxuryfinish19',
+        },
+		['luxuryfinish20'] = {
+            component = 'COMPONENT_SNSPISTOL_MK2_CAMO_09_SLIDE',
+            item = 'snspistol_mk2_luxuryfinish20',
+        },
+		['luxuryfinish21'] = {
+            component = 'COMPONENT_SNSPISTOL_MK2_CAMO_10_SLIDE',
+            item = 'snspistol_mk2_luxuryfinish21',
+        },
+		['luxuryfinish22'] = {
+            component = 'COMPONENT_SNSPISTOL_MK2_CAMO_IND_01_SLIDE',
+            item = 'snspistol_mk2_luxuryfinish22',
+        },
+    },
+	['WEAPON_REVOLVER_MK2'] = {
+        ['flashlight'] = {
+            component = 'COMPONENT_AT_PI_FLSH',
+            item = 'wep_flashlight',
+        },
+		['compensator'] = {
+            component = 'COMPONENT_AT_PI_COMP_03',
+            item = 'wep_compensator',
+        },
+        ['scope'] = {
+            component = 'COMPONENT_AT_SCOPE_MACRO_MK2',
+            item = 'revolver_mk2_scope',
+        },
+		['holosight'] = {
+            component = 'COMPONENT_AT_SIGHTS',
+            item = 'revolver_mk2_sight',
+        },
+        ['luxuryfinish1'] = {
+            component = 'COMPONENT_REVOLVER_MK2_CAMO',
+            item = 'revolver_mk2_luxuryfinish1',
+        },
+		['luxuryfinish2'] = {
+            component = 'COMPONENT_REVOLVER_MK2_CAMO_02',
+            item = 'revolver_mk2_luxuryfinish2',
+        },
+		['luxuryfinish3'] = {
+            component = 'COMPONENT_REVOLVER_MK2_CAMO_03',
+            item = 'revolver_mk2_luxuryfinish3',
+        },
+		['luxuryfinish4'] = {
+            component = 'COMPONENT_REVOLVER_MK2_CAMO_04',
+            item = 'revolver_mk2_luxuryfinish4',
+        },
+		['luxuryfinish5'] = {
+            component = 'COMPONENT_REVOLVER_MK2_CAMO_05',
+            item = 'revolver_mk2_luxuryfinish5',
+        },
+		['luxuryfinish6'] = {
+            component = 'COMPONENT_REVOLVER_MK2_CAMO_06',
+            item = 'revolver_mk2_luxuryfinish6',
+        },
+		['luxuryfinish7'] = {
+            component = 'COMPONENT_REVOLVER_MK2_CAMO_07',
+            item = 'revolver_mk2_luxuryfinish7',
+        },
+		['luxuryfinish8'] = {
+            component = 'COMPONENT_REVOLVER_MK2_CAMO_08',
+            item = 'revolver_mk2_luxuryfinish8',
+        },
+		['luxuryfinish9'] = {
+            component = 'COMPONENT_REVOLVER_MK2_CAMO_09',
+            item = 'revolver_mk2_luxuryfinish9',
+        },
+		['luxuryfinish10'] = {
+            component = 'COMPONENT_REVOLVER_MK2_CAMO_10',
+            item = 'revolver_mk2_luxuryfinish10',
+        },
+		['luxuryfinish11'] = {
+            component = 'COMPONENT_REVOLVER_MK2_CAMO_IND_01',
+            item = 'revolver_mk2_luxuryfinish11',
+        },
+    },
+	['WEAPON_RAYPISTOL'] = {
+        ['luxuryfinish1'] = {
+            component = 'COMPONENT_RAYPISTOL_VARMOD_XMAS18',
+            item = 'raypistol_luxuryfinish1',
+        },
+    },
+	['WEAPON_CERAMICPISTOL'] = {
+        ['defaultclip'] = {
+            component = 'COMPONENT_CERAMICPISTOL_CLIP_01',
+            item = 'ceramicpistol_defaultclip',
+            type = 'clip',
+        },
+        ['extendedclip'] = {
+            component = 'COMPONENT_CERAMICPISTOL_CLIP_02',
+            item = 'ceramicppistol_extendedclip',
+            type = 'clip',
+        },        
+        ['suppressor'] = {
+            component = 'COMPONENT_CERAMICPISTOL_SUPP',
+            item = 'pistol_suppressor',
+        },
+    },
+	['WEAPON_PISTOLXM3'] = {
+        ['suppressor'] = {
+            component = 'COMPONENT_PISTOLXM3_SUPP',
+            item = 'pistol_suppressor',
+        },
+    },
+	-- ['WEAPON_NAVYREVOLVER'] = {}, -- Placeholder, No usable components at this time
+	-- ['WEAPON_GADGETPISTOL'] = {}, -- Placeholder, No usable components at this time
+    -- ['WEAPON_FLAREGUN'] = {}, -- Placeholder, No usable components at this time
+	-- ['WEAPON_MARKSMANPISTOL'] = {}, -- Placeholder, No usable components at this time
+	-- ['WEAPON_STUNGUN'] = {}, -- Placeholder, No usable components at this time
+	-- ['WEAPON_STUNGUN_MP'] = {}, -- Placeholder, No usable components at this time
+	-- ['WEAPON_DOUBLEACTION'] = {}, -- Placeholder, No usable components at this time
+	
+	-- SMGS
+	['WEAPON_MICROSMG'] = {
         ['defaultclip'] = {
             component = 'COMPONENT_MICROSMG_CLIP_01',
             item = 'microsmg_defaultclip',
@@ -356,7 +858,7 @@ WeaponAttachments = {
         },
         ['flashlight'] = {
             component = 'COMPONENT_AT_PI_FLSH',
-            item = 'pistol_flashlight',
+            item = 'wep_flashlight',
         },
         ['scope'] = {
             component = 'COMPONENT_AT_SCOPE_MACRO',
@@ -366,12 +868,24 @@ WeaponAttachments = {
             component = 'COMPONENT_AT_AR_SUPP_02',
             item = 'smg_suppressor',
         },
-        ['luxuryfinish'] = {
+        ['luxuryfinish1'] = {
             component = 'COMPONENT_MICROSMG_VARMOD_LUXE',
-            item = 'microsmg_luxuryfinish',
+            item = 'microsmg_luxuryfinish1',
+        },
+		['luxuryfinish2'] = {
+            component = 'COMPONENT_MICROSMG_VARMOD_SECURITY',
+            item = 'microsmg_luxuryfinish2',
+        },
+		['luxuryfinish3'] = {
+            component = 'COMPONENT_MICROSMG_VARMOD_XM3',
+            item = 'microsmg_luxuryfinish3',
+        },
+		['luxuryfinish4'] = {
+            component = 'COMPONENT_MICROSMG_VARMOD_FRN',
+            item = 'microsmg_luxuryfinish4',
         },
     },
-    ['WEAPON_SMG'] = {
+    ['WEAPON_SMG'] = { 
         ['defaultclip'] = {
             component = 'COMPONENT_SMG_CLIP_01',
             item = 'smg_defaultclip',
@@ -389,7 +903,7 @@ WeaponAttachments = {
         },
         ['flashlight'] = {
             component = 'COMPONENT_AT_AR_FLSH',
-            item = 'rifle_flashlight',
+            item = 'wep_flashlight',
         },
         ['scope'] = {
             component = 'COMPONENT_AT_SCOPE_MACRO_02',
@@ -397,11 +911,11 @@ WeaponAttachments = {
         },
         ['suppressor'] = {
             component = 'COMPONENT_AT_PI_SUPP',
-            item = 'pistol_suppressor',
+            item = 'smg_suppressor',
         },
-        ['luxuryfinish'] = {
+        ['luxuryfinish1'] = {
             component = 'COMPONENT_SMG_VARMOD_LUXE',
-            item = 'smg_luxuryfinish',
+            item = 'smg_luxuryfinish1',
         },
     },
     ['WEAPON_ASSAULTSMG'] = {
@@ -417,22 +931,34 @@ WeaponAttachments = {
         },
         ['flashlight'] = {
             component = 'COMPONENT_AT_AR_FLSH',
-            item = 'rifle_flashlight',
+            item = 'wep_flashlight',
         },
         ['scope'] = {
             component = 'COMPONENT_AT_SCOPE_MACRO',
-            item = 'microsmg_scope',
+            item = 'assaultsmg_scope',
         },
         ['suppressor'] = {
             component = 'COMPONENT_AT_AR_SUPP_02',
             item = 'smg_suppressor',
         },
-        ['luxuryfinish'] = {
+        ['luxuryfinish1'] = {
             component = 'COMPONENT_ASSAULTSMG_VARMOD_LOWRIDER',
-            item = 'assaultsmg_luxuryfinish',
+            item = 'assaultsmg_luxuryfinish1',
         },
     },
-    ['WEAPON_MINISMG'] = {
+    ['WEAPON_GUSENBERG'] = {
+        ['defaultclip'] = {
+            component = 'COMPONENT_GUSENBERG_CLIP_01',
+            item = 'gusenberg_defaultclip',
+            type = 'clip',
+        },
+        ['extendedclip'] = {
+            component = 'COMPONENT_GUSENBERG_CLIP_02',
+            item = 'gusenberg_extendedclip',
+            type = 'clip',
+        },
+    },
+	['WEAPON_MINISMG'] = {
         ['defaultclip'] = {
             component = 'COMPONENT_MINISMG_CLIP_01',
             item = 'minismg_defaultclip',
@@ -462,7 +988,7 @@ WeaponAttachments = {
         },
         ['suppressor'] = {
             component = 'COMPONENT_AT_PI_SUPP',
-            item = 'pistol_suppressor',
+            item = 'smg_suppressor',
         },
     },
     ['WEAPON_COMBATPDW'] = {
@@ -483,7 +1009,7 @@ WeaponAttachments = {
         },
         ['flashlight'] = {
             component = 'COMPONENT_AT_AR_FLSH',
-            item = 'rifle_flashlight',
+            item = 'wep_flashlight',
         },
         ['grip'] = {
             component = 'COMPONENT_AT_AR_AFGRIP',
@@ -494,25 +1020,158 @@ WeaponAttachments = {
             item = 'combatpdw_scope',
         },
     },
-    -- SHOTGUNS
-    ['WEAPON_PUMPSHOTGUN'] = {
+	['WEAPON_SMG_MK2'] = {
+        ['defaultclip'] = {
+            component = 'COMPONENT_SMG_MK2_CLIP_01',
+            item = 'smg_mk2_defaultclip',
+            type = 'clip',
+        },
+        ['extendedclip'] = {
+            component = 'COMPONENT_SMG_MK2_CLIP_02',
+            item = 'smg_mk2_extendedclip',
+            type = 'clip',
+        },
         ['flashlight'] = {
             component = 'COMPONENT_AT_AR_FLSH',
-            item = 'rifle_flashlight',
+            item = 'wep_flashlight',
+        },
+		['suppressor'] = {
+            component = 'COMPONENT_AT_PI_SUPP',
+            item = 'smg_suppressor',
+        },
+        ['scopesmall'] = {
+            component = 'COMPONENT_AT_SCOPE_MACRO_02_SMG_MK2',
+            item = 'smg_mk2_scopesmall',
+        },
+		['scopemedium'] = {
+            component = 'COMPONENT_AT_SCOPE_SMALL_SMG_MK2',
+            item = 'smg_mk2_scopemedium',
+        },
+		['holosight'] = {
+            component = 'COMPONENT_AT_SIGHTS_SMG',
+            item = 'smg_mk2_sight',
+        },
+        ['muzzle1'] = {
+            component = 'COMPONENT_AT_MUZZLE_01',
+            item = 'smg_mk2_muzzle1',
+        },
+		['muzzle2'] = {
+            component = 'COMPONENT_AT_MUZZLE_02',
+            item = 'smg_mk2_muzzle2',
+        },
+		['muzzle3'] = {
+            component = 'COMPONENT_AT_MUZZLE_03',
+            item = 'smg_mk2_muzzle3',
+        },
+		['muzzle4'] = {
+            component = 'COMPONENT_AT_MUZZLE_04',
+            item = 'smg_mk2_muzzle4',
+        },
+		['muzzle5'] = {
+            component = 'COMPONENT_AT_MUZZLE_05',
+            item = 'smg_mk2_muzzle5',
+        },
+		['muzzle6'] = {
+            component = 'COMPONENT_AT_MUZZLE_06',
+            item = 'smg_mk2_muzzle6',
+        },
+		['muzzle7'] = {
+            component = 'COMPONENT_AT_MUZZLE_07',
+            item = 'smg_mk2_muzzle7',
+        },
+		['barrel1'] = {
+            component = 'COMPONENT_AT_SB_BARREL_01',
+            item = 'smg_mk2_barrel1',
+        },
+		['barrel2'] = {
+            component = 'COMPONENT_AT_SB_BARREL_02',
+            item = 'smg_mk2_barrel2',
+        },
+		['luxuryfinish1'] = {
+            component = 'COMPONENT_SMG_MK2_CAMO',
+            item = 'smg_mk2_luxuryfinish1',
+        },
+		['luxuryfinish2'] = {
+            component = 'COMPONENT_SMG_MK2_CAMO_02',
+            item = 'smg_mk2_luxuryfinish2',
+        },
+		['luxuryfinish3'] = {
+            component = 'COMPONENT_SMG_MK2_CAMO_03',
+            item = 'smg_mk2_luxuryfinish3',
+        },
+		['luxuryfinish4'] = {
+            component = 'COMPONENT_SMG_MK2_CAMO_04',
+            item = 'smg_mk2_luxuryfinish4',
+        },
+		['luxuryfinish5'] = {
+            component = 'COMPONENT_SMG_MK2_CAMO_05',
+            item = 'smg_mk2_luxuryfinish5',
+        },
+		['luxuryfinish6'] = {
+            component = 'COMPONENT_SMG_MK2_CAMO_06',
+            item = 'smg_mk2_luxuryfinish6',
+        },
+		['luxuryfinish7'] = {
+            component = 'COMPONENT_SMG_MK2_CAMO_07',
+            item = 'smg_mk2_luxuryfinish7',
+        },
+		['luxuryfinish8'] = {
+            component = 'COMPONENT_SMG_MK2_CAMO_08',
+            item = 'smg_mk2_luxuryfinish8',
+        },
+		['luxuryfinish9'] = {
+            component = 'COMPONENT_SMG_MK2_CAMO_09',
+            item = 'smg_mk2_luxuryfinish9',
+        },
+		['luxuryfinish10'] = {
+            component = 'COMPONENT_SMG_MK2_CAMO_10',
+            item = 'smg_mk2_luxuryfinish10',
+        },
+		['luxuryfinish11'] = {
+            component = 'COMPONENT_SMG_MK2_CAMO_IND_01',
+            item = 'smg_mk2_luxuryfinish11',
+        },
+    },
+    ['WEAPON_TECPISTOL'] = {
+        ['defaultclip'] = {
+            component = 'COMPONENT_TECPISTOL_CLIP_01',
+            item = 'tecpistol_defaultclip',
+            type = 'clip',
+        },
+        ['extendedclip'] = {
+            component = 'COMPONENT_TECPISTOL_CLIP_02',
+            item = 'tecpistol_extendedclip',
+            type = 'clip',
+        },
+    },
+	
+	-- SHOTGUNS
+	['WEAPON_PUMPSHOTGUN'] = {
+        ['flashlight'] = {
+            component = 'COMPONENT_AT_AR_FLSH',
+            item = 'wep_flashlight',
         },
         ['suppressor'] = {
             component = 'COMPONENT_AT_SR_SUPP',
             item = 'shotgun_suppressor',
         },
-        ['luxuryfinish'] = {
+        ['luxuryfinish1'] = {
+            component = 'COMPONENT_PUMPSHOTGUN_VARMOD_XM3',
+            item = 'pumpshotgun_luxuryfinish1',
+        },
+		['luxuryfinish2'] = {
+            component = 'COMPONENT_PUMPSHOTGUN_VARMOD_SECURITY',
+            item = 'pumpshotgun_luxuryfinish2',
+        },
+		['luxuryfinish3'] = {
             component = 'COMPONENT_PUMPSHOTGUN_VARMOD_LOWRIDER',
-            item = 'pumpshotgun_luxuryfinish',
+            item = 'pumpshotgun_luxuryfinish3',
         },
     },
     ['WEAPON_SAWNOFFSHOTGUN'] = {
-        ['luxuryfinish'] = {
+        ['luxuryfinish1'] = {
             component = 'COMPONENT_SAWNOFFSHOTGUN_VARMOD_LUXE',
-            item = 'sawnoffshotgun_luxuryfinish',
+            item = 'sawnoffshotgun_luxuryfinish1',
         },
     },
     ['WEAPON_ASSAULTSHOTGUN'] = {
@@ -523,34 +1182,34 @@ WeaponAttachments = {
         },
         ['extendedclip'] = {
             component = 'COMPONENT_ASSAULTSHOTGUN_CLIP_02',
-            item = 'assaultshotgun_extendedclip',
+            item = 'assaultshotgun_drum',
             type = 'clip',
         },
         ['flashlight'] = {
             component = 'COMPONENT_AT_AR_FLSH',
-            item = 'rifle_flashlight',
+            item = 'wep_flashlight',
         },
         ['suppressor'] = {
             component = 'COMPONENT_AT_AR_SUPP',
-            item = 'rifle_suppressor',
+            item = 'shotgun_suppressor',
         },
         ['grip'] = {
             component = 'COMPONENT_AT_AR_AFGRIP',
-            item = 'rifle_grip',
+            item = 'assaultshotgun_grip',
         },
     },
-    ['WEAPON_BULLPUPSHOTGUN'] = {
+	['WEAPON_BULLPUPSHOTGUN'] = {
         ['flashlight'] = {
             component = 'COMPONENT_AT_AR_FLSH',
-            item = 'rifle_flashlight',
+            item = 'wep_flashlight',
         },
         ['suppressor'] = {
             component = 'COMPONENT_AT_AR_SUPP_02',
-            item = 'smg_suppressor',
+            item = 'shotgun_suppressor',
         },
         ['grip'] = {
             component = 'COMPONENT_AT_AR_AFGRIP',
-            item = 'rifle_grip',
+            item = 'bullpupshotgun_grip',
         },
     },
     ['WEAPON_HEAVYSHOTGUN'] = {
@@ -571,29 +1230,103 @@ WeaponAttachments = {
         },
         ['flashlight'] = {
             component = 'COMPONENT_AT_AR_FLSH',
-            item = 'rifle_flashlight',
+            item = 'wep_flashlight',
         },
         ['suppressor'] = {
             component = 'COMPONENT_AT_AR_SUPP_02',
-            item = 'smg_suppressor',
+            item = 'shotgun_suppressor',
         },
         ['grip'] = {
             component = 'COMPONENT_AT_AR_AFGRIP',
-            item = 'rifle_grip',
+            item = 'heavyshotgun_grip',
         },
     },
     ['WEAPON_COMBATSHOTGUN'] = {
         ['flashlight'] = {
             component = 'COMPONENT_AT_AR_FLSH',
-            item = 'rifle_flashlight',
+            item = 'wep_flashlight',
         },
         ['suppressor'] = {
             component = 'COMPONENT_AT_AR_SUPP',
-            item = 'rifle_suppressor',
+            item = 'shotgun_suppressor',
         },
     },
-    -- RIFLES
-    ['WEAPON_ASSAULTRIFLE'] = {
+	['WEAPON_PUMPSHOTGUN_MK2'] = {
+        ['flashlight'] = {
+            component = 'COMPONENT_AT_AR_FLSH',
+            item = 'wep_flashlight',
+        },
+		['suppressor'] = {
+            component = 'COMPONENT_AT_SR_SUPP_03',
+            item = 'shotgun_suppressor',
+        },
+        ['scopesmall'] = {
+            component = 'COMPONENT_AT_SCOPE_MACRO_MK2',
+            item = 'pumpshotgun_mk2_scopesmall',
+        },
+		['scopemedium'] = {
+            component = 'COMPONENT_AT_SCOPE_SMALL_MK2',
+            item = 'pumpshotgun_mk2_scopemedium',
+        },
+		['holosight'] = {
+            component = 'COMPONENT_AT_SIGHTS',
+            item = 'pumpshotgun_mk2_sight',
+        },
+        ['muzzle1'] = {
+            component = 'COMPONENT_AT_MUZZLE_08',
+            item = 'pumpshotgun_mk2_muzzle1',
+        },
+		['luxuryfinish1'] = {
+            component = 'COMPONENT_PUMPSHOTGUN_MK2_CAMO',
+            item = 'pumpshotgun_mk2_luxuryfinish1',
+        },
+		['luxuryfinish2'] = {
+            component = 'COMPONENT_PUMPSHOTGUN_MK2_CAMO_02',
+            item = 'pumpshotgun_mk2_luxuryfinish2',
+        },
+		['luxuryfinish3'] = {
+            component = 'COMPONENT_PUMPSHOTGUN_MK2_CAMO_03',
+            item = 'pumpshotgun_mk2_luxuryfinish3',
+        },
+		['luxuryfinish4'] = {
+            component = 'COMPONENT_PUMPSHOTGUN_MK2_CAMO_04',
+            item = 'pumpshotgun_mk2_luxuryfinish4',
+        },
+		['luxuryfinish5'] = {
+            component = 'COMPONENT_PUMPSHOTGUN_MK2_CAMO_05',
+            item = 'pumpshotgun_mk2_luxuryfinish5',
+        },
+		['luxuryfinish6'] = {
+            component = 'COMPONENT_PUMPSHOTGUN_MK2_CAMO_06',
+            item = 'pumpshotgun_mk2_luxuryfinish6',
+        },
+		['luxuryfinish7'] = {
+            component = 'COMPONENT_PUMPSHOTGUN_MK2_CAMO_07',
+            item = 'pumpshotgun_mk2_luxuryfinish7',
+        },
+		['luxuryfinish8'] = {
+            component = 'COMPONENT_PUMPSHOTGUN_MK2_CAMO_08',
+            item = 'pumpshotgun_mk2_luxuryfinish8',
+        },
+		['luxuryfinish9'] = {
+            component = 'COMPONENT_PUMPSHOTGUN_MK2_CAMO_09',
+            item = 'pumpshotgun_mk2_luxuryfinish9',
+        },
+		['luxuryfinish10'] = {
+            component = 'COMPONENT_PUMPSHOTGUN_MK2_CAMO_10',
+            item = 'pumpshotgun_mk2_luxuryfinish10',
+        },
+		['luxuryfinish11'] = {
+            component = 'COMPONENT_PUMPSHOTGUN_MK2_CAMO_IND_01',
+            item = 'pumpshotgun_mk2_luxuryfinish11',
+        },
+    },
+	-- ['WEAPON_DBSHOTGUN'] = {}, -- Placeholder, No usable components at this time
+	-- ['WEAPON_AUTOSHOTGUN'] = {}, -- Placeholder, No usable components at this time
+	-- ['WEAPON_MUSKET'] = {}, -- Placeholder, No usable components at this time
+	
+	-- ASSAULT RIFLES
+	['WEAPON_ASSAULTRIFLE'] = {
         ['defaultclip'] = {
             component = 'COMPONENT_ASSAULTRIFLE_CLIP_01',
             item = 'assaultrifle_defaultclip',
@@ -611,11 +1344,11 @@ WeaponAttachments = {
         },
         ['flashlight'] = {
             component = 'COMPONENT_AT_AR_FLSH',
-            item = 'rifle_flashlight',
+            item = 'wep_flashlight',
         },
-        ['scope'] = {
+        ['scopesmall'] = {
             component = 'COMPONENT_AT_SCOPE_MACRO',
-            item = 'microsmg_scope',
+            item = 'assaultrifle_scopesmall',
         },
         ['suppressor'] = {
             component = 'COMPONENT_AT_AR_SUPP_02',
@@ -623,11 +1356,11 @@ WeaponAttachments = {
         },
         ['grip'] = {
             component = 'COMPONENT_AT_AR_AFGRIP',
-            item = 'rifle_grip',
+            item = 'assaultrifle_grip',
         },
-        ['luxuryfinish'] = {
+        ['luxuryfinish1'] = {
             component = 'COMPONENT_ASSAULTRIFLE_VARMOD_LUXE',
-            item = 'assaultrifle_luxuryfinish',
+            item = 'assaultrifle_luxuryfinish1',
         },
     },
     ['WEAPON_CARBINERIFLE'] = {
@@ -648,11 +1381,11 @@ WeaponAttachments = {
         },
         ['flashlight'] = {
             component = 'COMPONENT_AT_AR_FLSH',
-            item = 'rifle_flashlight',
+            item = 'wep_flashlight',
         },
-        ['scope'] = {
+        ['scopemedium'] = {
             component = 'COMPONENT_AT_SCOPE_MEDIUM',
-            item = 'carbinerifle_scope',
+            item = 'carbinerifle_scopemedium',
         },
         ['suppressor'] = {
             component = 'COMPONENT_AT_AR_SUPP',
@@ -660,11 +1393,15 @@ WeaponAttachments = {
         },
         ['grip'] = {
             component = 'COMPONENT_AT_AR_AFGRIP',
-            item = 'rifle_grip',
+            item = 'carbinerifle_grip',
         },
-        ['luxuryfinish'] = {
+        ['luxuryfinish1'] = {
             component = 'COMPONENT_CARBINERIFLE_VARMOD_LUXE',
-            item = 'carbinerifle_luxuryfinish',
+            item = 'carbinerifle_luxuryfinish1',
+        },
+		['luxuryfinish2'] = {
+            component = 'COMPONENT_CARBINERIFLE_VARMOD_MICH',
+            item = 'carbinerifle_luxuryfinish2',
         },
     },
     ['WEAPON_ADVANCEDRIFLE'] = {
@@ -680,23 +1417,19 @@ WeaponAttachments = {
         },
         ['flashlight'] = {
             component = 'COMPONENT_AT_AR_FLSH',
-            item = 'rifle_flashlight',
+            item = 'wep_flashlight',
         },
-        ['scope'] = {
+        ['scopesmall'] = {
             component = 'COMPONENT_AT_SCOPE_SMALL',
-            item = 'combatpdw_scope',
+            item = 'advancedrifle_scopesmall',
         },
         ['suppressor'] = {
             component = 'COMPONENT_AT_AR_SUPP',
             item = 'rifle_suppressor',
         },
-        ['grip'] = {
-            component = 'COMPONENT_AT_AR_AFGRIP',
-            item = 'rifle_grip',
-        },
-        ['luxuryfinish'] = {
+        ['luxuryfinish1'] = {
             component = 'COMPONENT_ADVANCEDRIFLE_VARMOD_LUXE',
-            item = 'advancedrifle_luxuryfinish',
+            item = 'advancedrifle_luxuryfinish1',
         },
     },
     ['WEAPON_SPECIALCARBINE'] = {
@@ -717,23 +1450,23 @@ WeaponAttachments = {
         },
         ['flashlight'] = {
             component = 'COMPONENT_AT_AR_FLSH',
-            item = 'rifle_flashlight',
+            item = 'wep_flashlight',
         },
-        ['scope'] = {
+        ['scopemedium'] = {
             component = 'COMPONENT_AT_SCOPE_MEDIUM',
-            item = 'carbinerifle_scope',
+            item = 'specialcarbine_scopemedium',
         },
         ['suppressor'] = {
             component = 'COMPONENT_AT_AR_SUPP_02',
-            item = 'smg_suppressor',
+            item = 'rifle_suppressor',
         },
         ['grip'] = {
             component = 'COMPONENT_AT_AR_AFGRIP',
-            item = 'rifle_grip',
+            item = 'specialcarbine_grip',
         },
-        ['luxuryfinish'] = {
+        ['luxuryfinish1'] = {
             component = 'COMPONENT_SPECIALCARBINE_VARMOD_LOWRIDER',
-            item = 'specialcarbine_luxuryfinish',
+            item = 'specialcarbine_luxuryfinish1',
         },
     },
     ['WEAPON_BULLPUPRIFLE'] = {
@@ -749,11 +1482,11 @@ WeaponAttachments = {
         },
         ['flashlight'] = {
             component = 'COMPONENT_AT_AR_FLSH',
-            item = 'rifle_flashlight',
+            item = 'wep_flashlight',
         },
-        ['scope'] = {
+        ['scopesmall'] = {
             component = 'COMPONENT_AT_SCOPE_SMALL',
-            item = 'combatpdw_scope',
+            item = 'bullpuprifle_scopesmall',
         },
         ['suppressor'] = {
             component = 'COMPONENT_AT_AR_SUPP',
@@ -761,11 +1494,11 @@ WeaponAttachments = {
         },
         ['grip'] = {
             component = 'COMPONENT_AT_AR_AFGRIP',
-            item = 'rifle_grip',
+            item = 'bullpuprifle_grip',
         },
-        ['luxuryfinish'] = {
+        ['luxuryfinish1'] = {
             component = 'COMPONENT_BULLPUPRIFLE_VARMOD_LOW',
-            item = 'bullpuprifle_luxuryfinish',
+            item = 'bullpuprifle_luxuryfinish1',
         },
     },
     ['WEAPON_COMPACTRIFLE'] = {
@@ -788,21 +1521,25 @@ WeaponAttachments = {
     ['WEAPON_HEAVYRIFLE'] = {
         ['defaultclip'] = {
             component = 'COMPONENT_HEAVYRIFLE_CLIP_01',
-            item = 'bullpuprifle_defaultclip',
+            item = 'heavyrifle_defaultclip',
             type = 'clip',
         },
         ['extendedclip'] = {
             component = 'COMPONENT_HEAVYRIFLE_CLIP_02',
-            item = 'bullpuprifle_extendedclip',
+            item = 'heavyrifle_extendedclip',
             type = 'clip',
         },
         ['flashlight'] = {
             component = 'COMPONENT_AT_AR_FLSH',
-            item = 'rifle_flashlight',
+            item = 'wep_flashlight',
         },
-        ['scope'] = {
+		['holosight'] = {
+            component = 'COMPONENT_HEAVYRIFLE_SIGHT_01',
+            item = 'heavyrifle_sight',
+        },
+        ['scopemedium'] = {
             component = 'COMPONENT_AT_SCOPE_MEDIUM',
-            item = 'carbinerifle_scope',
+            item = 'heavyrifle_scopemedium',
         },
         ['suppressor'] = {
             component = 'COMPONENT_AT_AR_SUPP',
@@ -810,73 +1547,680 @@ WeaponAttachments = {
         },
         ['grip'] = {
             component = 'COMPONENT_AT_AR_AFGRIP',
-            item = 'rifle_grip',
+            item = 'heavyrifle_grip',
         },
-        ['luxuryfinish'] = {
-            component = 'COMPONENT_BULLPUPRIFLE_VARMOD_LOW',
-            item = 'bullpuprifle_luxuryfinish',
+        ['luxuryfinish1'] = {
+            component = 'COMPONENT_HEAVYRIFLE_CAMO1',
+            item = 'heavyrifle_luxuryfinish1',
         },
     },
-    -- MACHINE GUNS
-    ['WEAPON_GUSENBERG'] = {
+	['WEAPON_ASSAULTRIFLE_MK2'] = {
         ['defaultclip'] = {
-            component = 'COMPONENT_GUSENBERG_CLIP_01',
-            item = 'gusenberg_defaultclip',
+            component = 'COMPONENT_ASSAULTRIFLE_MK2_CLIP_01',
+            item = 'assaultrifle_mk2_defaultclip',
             type = 'clip',
         },
         ['extendedclip'] = {
-            component = 'COMPONENT_GUSENBERG_CLIP_02',
-            item = 'gusenberg_extendedclip',
+            component = 'COMPONENT_ASSAULTRIFLE_MK2_CLIP_02',
+            item = 'assaultrifle_mk2_extendedclip',
             type = 'clip',
         },
-    },
-    -- LAUNCHERS
-    ['WEAPON_EMPLAUNCHER'] = {
-        ['defaultclip'] = {
-            component = 'COMPONENT_EMPLAUNCHER_CLIP_01',
-            item = 'emplauncher_defaultclip',
-            type = 'clip',
+        ['flashlight'] = {
+            component = 'COMPONENT_AT_AR_FLSH',
+            item = 'wep_flashlight',
+        },
+		['suppressor'] = {
+            component = 'COMPONENT_AT_AR_SUPP_02',
+            item = 'rifle_suppressor',
+        },
+		['grip'] = {
+            component = 'COMPONENT_AT_AR_AFGRIP_02',
+            item = 'assaultrifle_mk2_grip',
+        },
+		['holosight'] = {
+            component = 'COMPONENT_AT_SIGHTS',
+            item = 'assaultrifle_mk2_sight',
+        },
+		['scopesmall'] = {
+            component = 'COMPONENT_AT_SCOPE_MACRO_MK2',
+            item = 'assaultrifle_mk2_scopesmall',
+        },
+		['scopelarge'] = {
+            component = 'COMPONENT_AT_SCOPE_MEDIUM_MK2',
+            item = 'assaultrifle_mk2_scopelarge',
+        },
+        ['muzzle1'] = {
+            component = 'COMPONENT_AT_MUZZLE_01',
+            item = 'assaultrifle_mk2_muzzle1',
+        },
+		['muzzle2'] = {
+            component = 'COMPONENT_AT_MUZZLE_02',
+            item = 'assaultrifle_mk2_muzzle2',
+        },
+		['muzzle3'] = {
+            component = 'COMPONENT_AT_MUZZLE_03',
+            item = 'assaultrifle_mk2_muzzle3',
+        },
+		['muzzle4'] = {
+            component = 'COMPONENT_AT_MUZZLE_04',
+            item = 'assaultrifle_mk2_muzzle4',
+        },
+		['muzzle5'] = {
+            component = 'COMPONENT_AT_MUZZLE_05',
+            item = 'assaultrifle_mk2_muzzle5',
+        },
+		['muzzle6'] = {
+            component = 'COMPONENT_AT_MUZZLE_06',
+            item = 'assaultrifle_mk2_muzzle6',
+        },
+		['muzzle7'] = {
+            component = 'COMPONENT_AT_MUZZLE_07',
+            item = 'assaultrifle_mk2_muzzle7',
+        },
+		['barrel1'] = {
+            component = 'COMPONENT_AT_AR_BARREL_01',
+            item = 'assaultrifle_mk2_barrel1',
+        },
+		['barrel2'] = {
+            component = 'COMPONENT_AT_AR_BARREL_02',
+            item = 'assaultrifle_mk2_barrel2',
+        },
+		['luxuryfinish1'] = {
+            component = 'COMPONENT_ASSAULTRIFLE_MK2_CAMO',
+            item = 'assaultrifle_mk2_luxuryfinish1',
+        },
+		['luxuryfinish2'] = {
+            component = 'COMPONENT_ASSAULTRIFLE_MK2_CAMO_02',
+            item = 'assaultrifle_mk2_luxuryfinish2',
+        },
+		['luxuryfinish3'] = {
+            component = 'COMPONENT_ASSAULTRIFLE_MK2_CAMO_03',
+            item = 'assaultrifle_mk2_luxuryfinish3',
+        },
+		['luxuryfinish4'] = {
+            component = 'COMPONENT_ASSAULTRIFLE_MK2_CAMO_04',
+            item = 'assaultrifle_mk2_luxuryfinish4',
+        },
+		['luxuryfinish5'] = {
+            component = 'COMPONENT_ASSAULTRIFLE_MK2_CAMO_05',
+            item = 'assaultrifle_mk2_luxuryfinish5',
+        },
+		['luxuryfinish6'] = {
+            component = 'COMPONENT_ASSAULTRIFLE_MK2_CAMO_06',
+            item = 'assaultrifle_mk2_luxuryfinish6',
+        },
+		['luxuryfinish7'] = {
+            component = 'COMPONENT_ASSAULTRIFLE_MK2_CAMO_07',
+            item = 'assaultrifle_mk2_luxuryfinish7',
+        },
+		['luxuryfinish8'] = {
+            component = 'COMPONENT_ASSAULTRIFLE_MK2_CAMO_08',
+            item = 'assaultrifle_mk2_luxuryfinish8',
+        },
+		['luxuryfinish9'] = {
+            component = 'COMPONENT_ASSAULTRIFLE_MK2_CAMO_09',
+            item = 'assaultrifle_mk2_luxuryfinish9',
+        },
+		['luxuryfinish10'] = {
+            component = 'COMPONENT_ASSAULTRIFLE_MK2_CAMO_10',
+            item = 'assaultrifle_mk2_luxuryfinish10',
+        },
+		['luxuryfinish11'] = {
+            component = 'COMPONENT_ASSAULTRIFLE_MK2_CAMO_IND_01',
+            item = 'assaultrifle_mk2_luxuryfinish11',
         },
     },
-    -- SNIPERS
-    ['WEAPON_SNIPERRIFLE'] = {
+	['WEAPON_CARBINERIFLE_MK2'] = {
         ['defaultclip'] = {
-            component = 'COMPONENT_SNIPERRIFLE_CLIP_01',
-            item = 'sniperrifle_defaultclip',
+            component = 'COMPONENT_CARBINERIFLE_MK2_CLIP_01',
+            item = 'carbinerifle_mk2_defaultclip',
+            type = 'clip',
+        },
+        ['extendedclip'] = {
+            component = 'COMPONENT_CARBINERIFLE_MK2_CLIP_02',
+            item = 'carbinerifle_mk2_extendedclip',
+            type = 'clip',
+        },
+        ['flashlight'] = {
+            component = 'COMPONENT_AT_AR_FLSH',
+            item = 'wep_flashlight',
+        },
+		['suppressor'] = {
+            component = 'COMPONENT_AT_AR_SUPP',
+            item = 'rifle_suppressor',
+        },
+		['grip'] = {
+            component = 'COMPONENT_AT_AR_AFGRIP_02',
+            item = 'carbinerifle_mk2_grip',
+        },
+		['holosight'] = {
+            component = 'COMPONENT_AT_SIGHTS',
+            item = 'carbinerifle_mk2_sight',
+        },
+		['scopesmall'] = {
+            component = 'COMPONENT_AT_SCOPE_MACRO_MK2',
+            item = 'carbinerifle_mk2_scopesmall',
+        },
+		['scopelarge'] = {
+            component = 'COMPONENT_AT_SCOPE_MEDIUM_MK2',
+            item = 'carbinerifle_mk2_scopelarge',
+        },
+        ['muzzle1'] = {
+            component = 'COMPONENT_AT_MUZZLE_01',
+            item = 'carbinerifle_mk2_muzzle1',
+        },
+		['muzzle2'] = {
+            component = 'COMPONENT_AT_MUZZLE_02',
+            item = 'carbinerifle_mk2_muzzle2',
+        },
+		['muzzle3'] = {
+            component = 'COMPONENT_AT_MUZZLE_03',
+            item = 'carbinerifle_mk2_muzzle3',
+        },
+		['muzzle4'] = {
+            component = 'COMPONENT_AT_MUZZLE_04',
+            item = 'carbinerifle_mk2_muzzle4',
+        },
+		['muzzle5'] = {
+            component = 'COMPONENT_AT_MUZZLE_05',
+            item = 'carbinerifle_mk2_muzzle5',
+        },
+		['muzzle6'] = {
+            component = 'COMPONENT_AT_MUZZLE_06',
+            item = 'carbinerifle_mk2_muzzle6',
+        },
+		['muzzle7'] = {
+            component = 'COMPONENT_AT_MUZZLE_07',
+            item = 'carbinerifle_mk2_muzzle7',
+        },
+		['barrel1'] = {
+            component = 'COMPONENT_AT_CR_BARREL_01',
+            item = 'carbinerifle_mk2_barrel1',
+        },
+		['barrel2'] = {
+            component = 'COMPONENT_AT_CR_BARREL_02',
+            item = 'carbinerifle_mk2_barrel2',
+        },
+		['luxuryfinish1'] = {
+            component = 'COMPONENT_CARBINERIFLE_MK2_CAMO',
+            item = 'carbinerifle_mk2_luxuryfinish1',
+        },
+		['luxuryfinish2'] = {
+            component = 'COMPONENT_CARBINERIFLE_MK2_CAMO_02',
+            item = 'carbinerifle_mk2_luxuryfinish2',
+        },
+		['luxuryfinish3'] = {
+            component = 'COMPONENT_CARBINERIFLE_MK2_CAMO_03',
+            item = 'carbinerifle_mk2_luxuryfinish3',
+        },
+		['luxuryfinish4'] = {
+            component = 'COMPONENT_CARBINERIFLE_MK2_CAMO_04',
+            item = 'carbinerifle_mk2_luxuryfinish4',
+        },
+		['luxuryfinish5'] = {
+            component = 'COMPONENT_CARBINERIFLE_MK2_CAMO_05',
+            item = 'carbinerifle_mk2_luxuryfinish5',
+        },
+		['luxuryfinish6'] = {
+            component = 'COMPONENT_CARBINERIFLE_MK2_CAMO_06',
+            item = 'carbinerifle_mk2_luxuryfinish6',
+        },
+		['luxuryfinish7'] = {
+            component = 'COMPONENT_CARBINERIFLE_MK2_CAMO_07',
+            item = 'carbinerifle_mk2_luxuryfinish7',
+        },
+		['luxuryfinish8'] = {
+            component = 'COMPONENT_CARBINERIFLE_MK2_CAMO_08',
+            item = 'carbinerifle_mk2_luxuryfinish8',
+        },
+		['luxuryfinish9'] = {
+            component = 'COMPONENT_CARBINERIFLE_MK2_CAMO_09',
+            item = 'carbinerifle_mk2_luxuryfinish9',
+        },
+		['luxuryfinish10'] = {
+            component = 'COMPONENT_CARBINERIFLE_MK2_CAMO_10',
+            item = 'carbinerifle_mk2_luxuryfinish10',
+        },
+		['luxuryfinish11'] = {
+            component = 'COMPONENT_CARBINERIFLE_MK2_CAMO_IND_01',
+            item = 'carbinerifle_mk2_luxuryfinish11',
+        },
+    },
+	['WEAPON_SPECIALCARBINE_MK2'] = {
+        ['defaultclip'] = {
+            component = 'COMPONENT_SPECIALCARBINE_MK2_CLIP_01',
+            item = 'specialcarbine_mk2_defaultclip',
+            type = 'clip',
+        },
+        ['extendedclip'] = {
+            component = 'COMPONENT_SPECIALCARBINE_MK2_CLIP_02',
+            item = 'specialcarbine_mk2_extendedclip',
+            type = 'clip',
+        },
+		['suppressor'] = {
+            component = 'COMPONENT_AT_AR_SUPP_02',
+            item = 'rifle_suppressor',
+        },
+        ['holosight'] = {
+            component = 'COMPONENT_AT_SIGHTS',
+            item = 'specialcarbine_mk2_sight',
+        },
+		['scopesmall'] = {
+            component = 'COMPONENT_AT_SCOPE_MACRO_MK2',
+            item = 'specialcarbine_mk2_scopesmall',
+        },
+		['scopelarge'] = {
+            component = 'COMPONENT_AT_SCOPE_MEDIUM_MK2',
+            item = 'specialcarbine_mk2_scopelarge',
+        },
+        ['muzzle1'] = {
+            component = 'COMPONENT_AT_MUZZLE_01',
+            item = 'specialcarbine_mk2_muzzle1',
+        },
+		['muzzle2'] = {
+            component = 'COMPONENT_AT_MUZZLE_02',
+            item = 'specialcarbine_mk2_muzzle2',
+        },
+		['muzzle3'] = {
+            component = 'COMPONENT_AT_MUZZLE_03',
+            item = 'specialcarbine_mk2_muzzle3',
+        },
+		['muzzle4'] = {
+            component = 'COMPONENT_AT_MUZZLE_04',
+            item = 'specialcarbine_mk2_muzzle4',
+        },
+		['muzzle5'] = {
+            component = 'COMPONENT_AT_MUZZLE_05',
+            item = 'specialcarbine_mk2_muzzle5',
+        },
+		['muzzle6'] = {
+            component = 'COMPONENT_AT_MUZZLE_06',
+            item = 'specialcarbine_mk2_muzzle6',
+        },
+		['muzzle7'] = {
+            component = 'COMPONENT_AT_MUZZLE_07',
+            item = 'specialcarbine_mk2_muzzle7',
+        },
+		['barrel1'] = {
+            component = 'COMPONENT_AT_SC_BARREL_01',
+            item = 'specialcarbine_mk2_barrel1',
+        },
+		['barrel2'] = {
+            component = 'COMPONENT_AT_SC_BARREL_02',
+            item = 'specialcarbine_mk2_barrel2',
+        },
+		['grip'] = {
+            component = 'COMPONENT_AT_AR_AFGRIP_02',
+            item = 'specialcarbine_mk2_grip',
+        },
+		['luxuryfinish1'] = {
+            component = 'COMPONENT_SPECIALCARBINE_MK2_CAMO',
+            item = 'specialcarbine_mk2_luxuryfinish1',
+        },
+		['luxuryfinish2'] = {
+            component = 'COMPONENT_SPECIALCARBINE_MK2_CAMO_02',
+            item = 'specialcarbine_mk2_luxuryfinish2',
+        },
+		['luxuryfinish3'] = {
+            component = 'COMPONENT_SPECIALCARBINE_MK2_CAMO_03',
+            item = 'specialcarbine_mk2_luxuryfinish3',
+        },
+		['luxuryfinish4'] = {
+            component = 'COMPONENT_SPECIALCARBINE_MK2_CAMO_04',
+            item = 'specialcarbine_mk2_luxuryfinish4',
+        },
+		['luxuryfinish5'] = {
+            component = 'COMPONENT_SPECIALCARBINE_MK2_CAMO_05',
+            item = 'specialcarbine_mk2_luxuryfinish5',
+        },
+		['luxuryfinish6'] = {
+            component = 'COMPONENT_SPECIALCARBINE_MK2_CAMO_06',
+            item = 'specialcarbine_mk2_luxuryfinish6',
+        },
+		['luxuryfinish7'] = {
+            component = 'COMPONENT_SPECIALCARBINE_MK2_CAMO_07',
+            item = 'specialcarbine_mk2_luxuryfinish7',
+        },
+		['luxuryfinish8'] = {
+            component = 'COMPONENT_SPECIALCARBINE_MK2_CAMO_08',
+            item = 'specialcarbine_mk2_luxuryfinish8',
+        },
+		['luxuryfinish9'] = {
+            component = 'COMPONENT_SPECIALCARBINE_MK2_CAMO_09',
+            item = 'specialcarbine_mk2_luxuryfinish9',
+        },
+		['luxuryfinish10'] = {
+            component = 'COMPONENT_SPECIALCARBINE_MK2_CAMO_10',
+            item = 'specialcarbine_mk2_luxuryfinish10',
+        },
+		['luxuryfinish11'] = {
+            component = 'COMPONENT_SPECIALCARBINE_MK2_CAMO_IND_01',
+            item = 'specialcarbine_mk2_luxuryfinish11',
+        },
+    },
+	['WEAPON_BULLPUPRIFLE_MK2'] = {
+        ['defaultclip'] = {
+            component = 'COMPONENT_BULLPUPRIFLE_MK2_CLIP_01',
+            item = 'bullpuprifle_mk2_defaultclip',
+            type = 'clip',
+        },
+        ['extendedclip'] = {
+            component = 'COMPONENT_BULLPUPRIFLE_MK2_CLIP_02',
+            item = 'bullpuprifle_mk2_extendedclip',
+            type = 'clip',
+        },
+		['suppressor'] = {
+            component = 'COMPONENT_AT_AR_SUPP',
+            item = 'rifle_suppressor',
+        },
+        ['holosight'] = {
+            component = 'COMPONENT_AT_SIGHTS',
+            item = 'bullpuprifle_mk2_sight',
+        },
+		['scopesmall'] = {
+            component = 'COMPONENT_AT_SCOPE_MACRO_02_MK2',
+            item = 'bullpuprifle_mk2_scopesmall',
+        },
+		['scopemedium'] = {
+            component = 'COMPONENT_AT_SCOPE_SMALL_MK2',
+            item = 'bullpuprifle_mk2_scopemedium',
+        },
+        ['muzzle1'] = {
+            component = 'COMPONENT_AT_MUZZLE_01',
+            item = 'bullpuprifle_mk2_muzzle1',
+        },
+		['muzzle2'] = {
+            component = 'COMPONENT_AT_MUZZLE_02',
+            item = 'bullpuprifle_mk2_muzzle2',
+        },
+		['muzzle3'] = {
+            component = 'COMPONENT_AT_MUZZLE_03',
+            item = 'bullpuprifle_mk2_muzzle3',
+        },
+		['muzzle4'] = {
+            component = 'COMPONENT_AT_MUZZLE_04',
+            item = 'bullpuprifle_mk2_muzzle4',
+        },
+		['muzzle5'] = {
+            component = 'COMPONENT_AT_MUZZLE_05',
+            item = 'bullpuprifle_mk2_muzzle5',
+        },
+		['muzzle6'] = {
+            component = 'COMPONENT_AT_MUZZLE_06',
+            item = 'bullpuprifle_mk2_muzzle6',
+        },
+		['muzzle7'] = {
+            component = 'COMPONENT_AT_MUZZLE_07',
+            item = 'bullpuprifle_mk2_muzzle7',
+        },
+		['barrel1'] = {
+            component = 'COMPONENT_AT_BP_BARREL_01',
+            item = 'bullpuprifle_mk2_barrel1',
+        },
+		['barrel2'] = {
+            component = 'COMPONENT_AT_BP_BARREL_02',
+            item = 'bullpuprifle_mk2_barrel2',
+        },
+		['grip'] = {
+            component = 'COMPONENT_AT_AR_AFGRIP_02',
+            item = 'bullpuprifle_mk2_grip',
+        },
+		['luxuryfinish1'] = {
+            component = 'COMPONENT_BULLPUPRIFLE_MK2_CAMO',
+            item = 'bullpuprifle_mk2_luxuryfinish1',
+        },
+		['luxuryfinish2'] = {
+            component = 'COMPONENT_BULLPUPRIFLE_MK2_CAMO_02',
+            item = 'bullpuprifle_mk2_luxuryfinish2',
+        },
+		['luxuryfinish3'] = {
+            component = 'COMPONENT_BULLPUPRIFLE_MK2_CAMO_03',
+            item = 'bullpuprifle_mk2_luxuryfinish3',
+        },
+		['luxuryfinish4'] = {
+            component = 'COMPONENT_BULLPUPRIFLE_MK2_CAMO_04',
+            item = 'bullpuprifle_mk2_luxuryfinish4',
+        },
+		['luxuryfinish5'] = {
+            component = 'COMPONENT_BULLPUPRIFLE_MK2_CAMO_05',
+            item = 'bullpuprifle_mk2_luxuryfinish5',
+        },
+		['luxuryfinish6'] = {
+            component = 'COMPONENT_BULLPUPRIFLE_MK2_CAMO_06',
+            item = 'bullpuprifle_mk2_luxuryfinish6',
+        },
+		['luxuryfinish7'] = {
+            component = 'COMPONENT_BULLPUPRIFLE_MK2_CAMO_07',
+            item = 'bullpuprifle_mk2_luxuryfinish7',
+        },
+		['luxuryfinish8'] = {
+            component = 'COMPONENT_BULLPUPRIFLE_MK2_CAMO_08',
+            item = 'bullpuprifle_mk2_luxuryfinish8',
+        },
+		['luxuryfinish9'] = {
+            component = 'COMPONENT_BULLPUPRIFLE_MK2_CAMO_09',
+            item = 'bullpuprifle_mk2_luxuryfinish9',
+        },
+		['luxuryfinish10'] = {
+            component = 'COMPONENT_BULLPUPRIFLE_MK2_CAMO_10',
+            item = 'bullpuprifle_mk2_luxuryfinish10',
+        },
+		['luxuryfinish11'] = {
+            component = 'COMPONENT_BULLPUPRIFLE_MK2_CAMO_IND_01',
+            item = 'bullpuprifle_mk2_luxuryfinish11',
+        },
+    },
+	['WEAPON_MILITARYRIFLE'] = {
+        ['defaultclip'] = {
+            component = 'COMPONENT_MILITARYRIFLE_CLIP_01',
+            item = 'militaryrifle_defaultclip',
+            type = 'clip',
+        },
+        ['extendedclip'] = {
+            component = 'COMPONENT_MILITARYRIFLE_CLIP_02',
+            item = 'militaryrifle_extendedclip',
+            type = 'clip',
+        },
+        ['flashlight'] = {
+            component = 'COMPONENT_AT_AR_FLSH',
+            item = 'wep_flashlight',
+        },
+        ['ironsights'] = {
+            component = 'COMPONENT_MILITARYRIFLE_SIGHT_01',
+            item = 'militaryrifle_ironsights',
+        },
+		['scopesmall'] = {
+            component = 'COMPONENT_AT_SCOPE_SMALL',
+            item = 'militaryrifle_scopesmall',
         },
         ['suppressor'] = {
-            component = 'COMPONENT_AT_AR_SUPP_02',
-            item = 'smg_suppressor',
-        },
-        ['scope'] = {
-            component = 'COMPONENT_AT_SCOPE_LARGE',
-            item = 'sniper_scope',
-            type = 'scope',
-        },
-        ['advancedscope'] = {
-            component = 'COMPONENT_AT_SCOPE_MAX',
-            item = 'snipermax_scope',
-            type = 'scope',
-        },
-        ['grip'] = {
-            component = 'COMPONENT_SNIPERRIFLE_VARMOD_LUXE',
-            item = 'sniper_grip',
+            component = 'COMPONENT_AT_AR_SUPP',
+            item = 'rifle_suppressor',
         },
     },
-    ['WEAPON_HEAVYSNIPER'] = {
+	['WEAPON_TACTICALRIFLE'] = {
         ['defaultclip'] = {
-            component = 'COMPONENT_HEAVYSNIPER_CLIP_01',
-            item = 'heavysniper_defaultclip',
+            component = 'COMPONENT_TACTICALRIFLE_CLIP_01',
+            item = 'tacticalrifle_defaultclip',
+            type = 'clip',
         },
-        ['scope'] = {
+        ['extendedclip'] = {
+            component = 'COMPONENT_TACTICALRIFLE_CLIP_02',
+            item = 'tacticalrifle_extendedclip',
+            type = 'clip',
+        },
+    },
+	
+	-- MACHINE GUNS
+	['WEAPON_MG'] = {
+        ['defaultclip'] = {
+            component = 'COMPONENT_MG_CLIP_01',
+            item = 'mg_defaultclip',
+            type = 'clip',
+        },
+        ['extendedclip'] = {
+            component = 'COMPONENT_MG_CLIP_02',
+            item = 'mg_extendedclip',
+            type = 'clip',
+        },
+		['scopesmall'] = {
+            component = 'COMPONENT_AT_SCOPE_SMALL_02',
+            item = 'mg_scopesmall',
+        },
+		['luxuryfinish1'] = {
+            component = 'COMPONENT_MG_VARMOD_LOWRIDER',
+            item = 'mg_luxuryfinish1',
+        },
+    },
+	['WEAPON_COMBATMG'] = {
+        ['defaultclip'] = {
+            component = 'COMPONENT_COMBATMG_CLIP_01',
+            item = 'combatmg_defaultclip',
+            type = 'clip',
+        },
+        ['extendedclip'] = {
+            component = 'COMPONENT_COMBATMG_CLIP_02',
+            item = 'combatmg_extendedclip',
+            type = 'clip',
+        },
+		['scopemedium'] = {
+            component = 'COMPONENT_AT_SCOPE_MEDIUM',
+            item = 'combatmg_scopemedium',
+        },
+		['grip'] = {
+            component = 'COMPONENT_AT_AR_AFGRIP',
+            item = 'combatmg_grip',
+        },
+		['luxuryfinish1'] = {
+            component = 'COMPONENT_COMBATMG_VARMOD_LOWRIDER',
+            item = 'combatmg_luxuryfinish1',
+        },
+    },
+	['WEAPON_COMBATMG_MK2'] = {
+        ['defaultclip'] = {
+            component = 'COMPONENT_COMBATMG_MK2_CLIP_01',
+            item = 'combatmg_mk2_defaultclip',
+            type = 'clip',
+        },
+        ['extendedclip'] = {
+            component = 'COMPONENT_COMBATMG_MK2_CLIP_02',
+            item = 'combatmg_mk2_extendedclip',
+            type = 'clip',
+        },
+        ['holosight'] = {
+            component = 'COMPONENT_AT_SIGHTS',
+            item = 'combatmg_mk2_sight',
+        },
+		['scopemedium'] = {
+            component = 'COMPONENT_AT_SCOPE_SMALL_MK2',
+            item = 'combatmg_mk2_scopemedium',
+        },
+		['scopelarge'] = {
+            component = 'COMPONENT_AT_SCOPE_MEDIUM_MK2',
+            item = 'combatmg_mk2_scopelarge',
+        },
+        ['muzzle1'] = {
+            component = 'COMPONENT_AT_MUZZLE_01',
+            item = 'combatmg_mk2_muzzle1',
+        },
+		['muzzle2'] = {
+            component = 'COMPONENT_AT_MUZZLE_02',
+            item = 'combatmg_mk2_muzzle2',
+        },
+		['muzzle3'] = {
+            component = 'COMPONENT_AT_MUZZLE_03',
+            item = 'combatmg_mk2_muzzle3',
+        },
+		['muzzle4'] = {
+            component = 'COMPONENT_AT_MUZZLE_04',
+            item = 'combatmg_mk2_muzzle4',
+        },
+		['muzzle5'] = {
+            component = 'COMPONENT_AT_MUZZLE_05',
+            item = 'combatmg_mk2_muzzle5',
+        },
+		['muzzle6'] = {
+            component = 'COMPONENT_AT_MUZZLE_06',
+            item = 'combatmg_mk2_muzzle6',
+        },
+		['muzzle7'] = {
+            component = 'COMPONENT_AT_MUZZLE_07',
+            item = 'combatmg_mk2_muzzle7',
+        },
+		['barrel1'] = {
+            component = 'COMPONENT_AT_MG_BARREL_01',
+            item = 'combatmg_mk2_barrel1',
+        },
+		['barrel2'] = {
+            component = 'COMPONENT_AT_MG_BARREL_02',
+            item = 'combatmg_mk2_barrel2',
+        },
+		['luxuryfinish1'] = {
+            component = 'COMPONENT_COMBATMG_MK2_CAMO',
+            item = 'combatmg_mk2_luxuryfinish1',
+        },
+		['luxuryfinish2'] = {
+            component = 'COMPONENT_COMBATMG_MK2_CAMO_02',
+            item = 'combatmg_mk2_luxuryfinish2',
+        },
+		['luxuryfinish3'] = {
+            component = 'COMPONENT_COMBATMG_MK2_CAMO_03',
+            item = 'combatmg_mk2_luxuryfinish3',
+        },
+		['luxuryfinish4'] = {
+            component = 'COMPONENT_COMBATMG_MK2_CAMO_04',
+            item = 'combatmg_mk2_luxuryfinish4',
+        },
+		['luxuryfinish5'] = {
+            component = 'COMPONENT_COMBATMG_MK2_CAMO_05',
+            item = 'combatmg_mk2_luxuryfinish5',
+        },
+		['luxuryfinish6'] = {
+            component = 'COMPONENT_COMBATMG_MK2_CAMO_06',
+            item = 'combatmg_mk2_luxuryfinish6',
+        },
+		['luxuryfinish7'] = {
+            component = 'COMPONENT_COMBATMG_MK2_CAMO_07',
+            item = 'combatmg_mk2_luxuryfinish7',
+        },
+		['luxuryfinish8'] = {
+            component = 'COMPONENT_COMBATMG_MK2_CAMO_08',
+            item = 'combatmg_mk2_luxuryfinish8',
+        },
+		['luxuryfinish9'] = {
+            component = 'COMPONENT_COMBATMG_MK2_CAMO_09',
+            item = 'combatmg_mk2_luxuryfinish9',
+        },
+		['luxuryfinish10'] = {
+            component = 'COMPONENT_COMBATMG_MK2_CAMO_10',
+            item = 'combatmg_mk2_luxuryfinish10',
+        },
+		['luxuryfinish11'] = {
+            component = 'COMPONENT_COMBATMG_MK2_CAMO_IND_01',
+            item = 'combatmg_mk2_luxuryfinish11',
+        },
+    },
+	-- ['WEAPON_RAYCARBINE'] = {}, -- Placeholder, No usable components at this time
+	
+	-- SNIPER RIFLES
+	['WEAPON_SNIPERRIFLE'] = {
+        ['suppressor'] = {
+            component = 'COMPONENT_AT_AR_SUPP_02',
+            item = 'sniper_suppressor',
+        },
+		['scopemedium'] = {
             component = 'COMPONENT_AT_SCOPE_LARGE',
-            item = 'sniper_scope',
+            item = 'sniperrifle_scopemedium',
             type = 'scope',
         },
-        ['advancedscope'] = {
+        ['scopelarge'] = {
             component = 'COMPONENT_AT_SCOPE_MAX',
-            item = 'snipermax_scope',
+            item = 'sniperrifle_scopelarge',
             type = 'scope',
+        },
+        ['luxuryfinish1'] = {
+            component = 'COMPONENT_SNIPERRIFLE_VARMOD_LUXE',
+            item = 'sniperrifle_luxuryfinish1',
         },
     },
     ['WEAPON_MARKSMANRIFLE'] = {
@@ -892,25 +2236,239 @@ WeaponAttachments = {
         },
         ['flashlight'] = {
             component = 'COMPONENT_AT_AR_FLSH',
-            item = 'rifle_flashlight',
+            item = 'wep_flashlight',
         },
-        ['scope'] = {
+        ['scopelarge'] = {
             component = 'COMPONENT_AT_SCOPE_LARGE_FIXED_ZOOM',
-            item = 'marksmanrifle_scope',
+            item = 'marksmanrifle_scopelarge',
         },
         ['suppressor'] = {
             component = 'COMPONENT_AT_AR_SUPP',
-            item = 'rifle_suppressor',
+            item = 'sniper_suppressor',
         },
         ['grip'] = {
             component = 'COMPONENT_AT_AR_AFGRIP',
-            item = 'rifle_grip',
+            item = 'marksmanrifle_grip',
         },
-        ['luxuryfinish'] = {
+        ['luxuryfinish1'] = {
             component = 'COMPONENT_MARKSMANRIFLE_VARMOD_LUXE',
-            item = 'marksmanrifle_luxuryfinish',
+            item = 'marksmanrifle_luxuryfinish1',
         },
     },
+	['WEAPON_HEAVYSNIPER_MK2'] = {
+        ['defaultclip'] = {
+            component = 'COMPONENT_HEAVYSNIPER_MK2_CLIP_01',
+            item = 'heavysniper_mk2_defaultclip',
+            type = 'clip',
+        },
+        ['extendedclip'] = {
+            component = 'COMPONENT_HEAVYSNIPER_MK2_CLIP_02',
+            item = 'heavysniper_mk2_extendedclip',
+            type = 'clip',
+        },
+		['suppressor'] = {
+            component = 'COMPONENT_AT_SR_SUPP_03',
+            item = 'sniper_suppressor',
+        },
+        ['scopelarge'] = {
+            component = 'COMPONENT_AT_SCOPE_MAX',
+            item = 'heavysniper_mk2_scopelarge',
+        },
+        ['muzzle1'] = {
+            component = 'COMPONENT_AT_MUZZLE_08',
+            item = 'heavysniper_mk2_muzzle1',
+        },
+		['muzzle2'] = {
+            component = 'COMPONENT_AT_MUZZLE_09',
+            item = 'heavysniper_mk2_muzzle2',
+        },
+		['barrel1'] = {
+            component = 'COMPONENT_AT_SR_BARREL_01',
+            item = 'heavysniper_mk2_barrel1',
+        },
+		['barrel2'] = {
+            component = 'COMPONENT_AT_SR_BARREL_02',
+            item = 'heavysniper_mk2_barrel2',
+        },
+		['luxuryfinish1'] = {
+            component = 'COMPONENT_HEAVYSNIPER_MK2_CAMO',
+            item = 'heavysniper_mk2_luxuryfinish1',
+        },
+		['luxuryfinish2'] = {
+            component = 'COMPONENT_HEAVYSNIPER_MK2_CAMO_02',
+            item = 'heavysniper_mk2_luxuryfinish2',
+        },
+		['luxuryfinish3'] = {
+            component = 'COMPONENT_HEAVYSNIPER_MK2_CAMO_03',
+            item = 'heavysniper_mk2_luxuryfinish3',
+        },
+		['luxuryfinish4'] = {
+            component = 'COMPONENT_HEAVYSNIPER_MK2_CAMO_04',
+            item = 'heavysniper_mk2_luxuryfinish4',
+        },
+		['luxuryfinish5'] = {
+            component = 'COMPONENT_HEAVYSNIPER_MK2_CAMO_05',
+            item = 'heavysniper_mk2_luxuryfinish5',
+        },
+		['luxuryfinish6'] = {
+            component = 'COMPONENT_HEAVYSNIPER_MK2_CAMO_06',
+            item = 'heavysniper_mk2_luxuryfinish6',
+        },
+		['luxuryfinish7'] = {
+            component = 'COMPONENT_HEAVYSNIPER_MK2_CAMO_07',
+            item = 'heavysniper_mk2_luxuryfinish7',
+        },
+		['luxuryfinish8'] = {
+            component = 'COMPONENT_HEAVYSNIPER_MK2_CAMO_08',
+            item = 'heavysniper_mk2_luxuryfinish8',
+        },
+		['luxuryfinish9'] = {
+            component = 'COMPONENT_HEAVYSNIPER_MK2_CAMO_09',
+            item = 'heavysniper_mk2_luxuryfinish9',
+        },
+		['luxuryfinish10'] = {
+            component = 'COMPONENT_HEAVYSNIPER_MK2_CAMO_10',
+            item = 'heavysniper_mk2_luxuryfinish10',
+        },
+		['luxuryfinish11'] = {
+            component = 'COMPONENT_HEAVYSNIPER_MK2_CAMO_IND_01',
+            item = 'heavysniper_mk2_luxuryfinish11',
+        },
+    },
+	['WEAPON_MARKSMANRIFLE_MK2'] = {
+        ['defaultclip'] = {
+            component = 'COMPONENT_MARKSMANRIFLE_MK2_CLIP_01',
+            item = 'marksmanrifle_mk2_defaultclip',
+            type = 'clip',
+        },
+        ['extendedclip'] = {
+            component = 'COMPONENT_MARKSMANRIFLE_MK2_CLIP_02',
+            item = 'marksmanrifle_mk2_extendedclip',
+            type = 'clip',
+        },
+		['suppressor'] = {
+            component = 'COMPONENT_AT_AR_SUPP',
+            item = 'sniper_suppressor',
+        },
+        ['holosight'] = {
+            component = 'COMPONENT_AT_SIGHTS',
+            item = 'marksmanrifle_mk2_sight',
+        },
+		['scopemedium'] = {
+            component = 'COMPONENT_AT_SCOPE_MEDIUM_MK2',
+            item = 'marksmanrifle_mk2_scopemedium',
+        },
+		['scopelarge'] = {
+            component = 'COMPONENT_AT_SCOPE_LARGE_FIXED_ZOOM_MK2',
+            item = 'marksmanrifle_mk2_scopelarge',
+        },
+        ['muzzle1'] = {
+            component = 'COMPONENT_AT_MUZZLE_01',
+            item = 'marksmanrifle_mk2__muzzle1',
+        },
+		['muzzle2'] = {
+            component = 'COMPONENT_AT_MUZZLE_02',
+            item = 'marksmanrifle_mk2__muzzle2',
+        },
+		['muzzle3'] = {
+            component = 'COMPONENT_AT_MUZZLE_03',
+            item = 'marksmanrifle_mk2__muzzle3',
+        },
+		['muzzle4'] = {
+            component = 'COMPONENT_AT_MUZZLE_04',
+            item = 'marksmanrifle_mk2__muzzle4',
+        },
+		['muzzle5'] = {
+            component = 'COMPONENT_AT_MUZZLE_05',
+            item = 'marksmanrifle_mk2__muzzle5',
+        },
+		['muzzle6'] = {
+            component = 'COMPONENT_AT_MUZZLE_06',
+            item = 'marksmanrifle_mk2__muzzle6',
+        },
+		['muzzle7'] = {
+            component = 'COMPONENT_AT_MUZZLE_07',
+            item = 'marksmanrifle_mk2__muzzle7',
+        },
+		['barrel1'] = {
+            component = 'COMPONENT_AT_MRFL_BARREL_01',
+            item = 'marksmanrifle_mk2_barrel1',
+        },
+		['barrel2'] = {
+            component = 'COMPONENT_AT_MRFL_BARREL_02',
+            item = 'marksmanrifle_mk2_barrel2',
+        },
+		['grip'] = {
+            component = 'COMPONENT_AT_AR_AFGRIP_02',
+            item = 'marksmanrifle_mk2_grip',
+        },
+		['luxuryfinish1'] = {
+            component = 'COMPONENT_MARKSMANRIFLE_MK2_CAMO',
+            item = 'marksmanrifle_mk2_luxuryfinish1',
+        },
+		['luxuryfinish2'] = {
+            component = 'COMPONENT_MARKSMANRIFLE_MK2_CAMO_02',
+            item = 'marksmanrifle_mk2_luxuryfinish2',
+        },
+		['luxuryfinish3'] = {
+            component = 'COMPONENT_MARKSMANRIFLE_MK2_CAMO_03',
+            item = 'marksmanrifle_mk2_luxuryfinish3',
+        },
+		['luxuryfinish4'] = {
+            component = 'COMPONENT_MARKSMANRIFLE_MK2_CAMO_04',
+            item = 'marksmanrifle_mk2_luxuryfinish4',
+        },
+		['luxuryfinish5'] = {
+            component = 'COMPONENT_MARKSMANRIFLE_MK2_CAMO_05',
+            item = 'marksmanrifle_mk2_luxuryfinish5',
+        },
+		['luxuryfinish6'] = {
+            component = 'COMPONENT_MARKSMANRIFLE_MK2_CAMO_06',
+            item = 'marksmanrifle_mk2_luxuryfinish6',
+        },
+		['luxuryfinish7'] = {
+            component = 'COMPONENT_MARKSMANRIFLE_MK2_CAMO_07',
+            item = 'marksmanrifle_mk2_luxuryfinish7',
+        },
+		['luxuryfinish8'] = {
+            component = 'COMPONENT_MARKSMANRIFLE_MK2_CAMO_08',
+            item = 'marksmanrifle_mk2_luxuryfinish8',
+        },
+		['luxuryfinish9'] = {
+            component = 'COMPONENT_MARKSMANRIFLE_MK2_CAMO_09',
+            item = 'marksmanrifle_mk2_luxuryfinish9',
+        },
+		['luxuryfinish10'] = {
+            component = 'COMPONENT_MARKSMANRIFLE_MK2_CAMO_10',
+            item = 'marksmanrifle_mk2_luxuryfinish10',
+        },
+		['luxuryfinish11'] = {
+            component = 'COMPONENT_MARKSMANRIFLE_MK2_CAMO_IND_01',
+            item = 'marksmanrifle_mk2_luxuryfinish11',
+        },
+		-- ['WEAPON_HEAVYSNIPER'] = {}, -- Placeholder, No usable components at this time
+		-- ['WEAPON_PRECISIONRIFLE'] = {}, -- Placeholder, No usable components at this time
+    },
+	-- ['WEAPON_PRECISIONRIFLE'] = {}, -- Placeholder, No usable components at this time
+	
+	-- HEAVY WEAPONS
+    ['WEAPON_RPG'] = {
+        ['luxuryfinish1'] = {
+            component = 'COMPONENT_RPG_VARMOD_TVR',
+            item = 'rpg_luxuryfinish1',
+        },
+    },
+	-- ['WEAPON_GRENADELAUNCHER'] = {}, -- Placeholder, No usable components at this time
+    -- ['WEAPON_GRENADELAUNCHER_SMOKE'] = {}, -- Placeholder, No usable components at this time
+	-- ['WEAPON_RAYMINIGUN'] = {}, -- Placeholder, No usable components at this time
+	-- ['WEAPON_MINIGUN'] = {}, -- Placeholder, No usable components at this time
+    -- ['WEAPON_FIREWORK'] = {}, -- Placeholder, No usable components at this time
+    -- ['WEAPON_EMPLAUNCHER'] = {}, -- Placeholder, No usable components at this time
+	-- ['WEAPON_COMPACTLAUNCHER'] = {}, -- Placeholder, No usable components at this time
+	-- ['WEAPON_RAILGUN'] = {}, -- Placeholder, No usable components at this time
+	-- ['WEAPON_HOMINGLAUNCHER'] = {}, -- Placeholder, No usable components at this time
+    -- ['WEAPON_RAILGUNXM3'] = {}, -- Placeholder, No usable components at this time
+	
 }
 
 local function getConfigWeaponAttachments(weapon)

--- a/config.lua
+++ b/config.lua
@@ -653,9 +653,9 @@ WeaponAttachments = {
             component = 'COMPONENT_AT_PI_COMP_02',
             item = 'wep_compensator',
         },
-        ['scope'] = {
+        ['scopesmall'] = {
             component = 'COMPONENT_AT_PI_RAIL_02',
-            item = 'snspistol_mk2_scope',
+            item = 'snspistol_mk2_scopesmall',
         },
 		['luxuryfinish1'] = {
             component = 'COMPONENT_SNSPISTOL_MK2_CAMO',
@@ -755,9 +755,9 @@ WeaponAttachments = {
             component = 'COMPONENT_AT_PI_COMP_03',
             item = 'wep_compensator',
         },
-        ['scope'] = {
+        ['scopesmall'] = {
             component = 'COMPONENT_AT_SCOPE_MACRO_MK2',
-            item = 'revolver_mk2_scope',
+            item = 'revolver_mk2_scopesmall',
         },
 		['holosight'] = {
             component = 'COMPONENT_AT_SIGHTS',
@@ -860,9 +860,9 @@ WeaponAttachments = {
             component = 'COMPONENT_AT_PI_FLSH',
             item = 'wep_flashlight',
         },
-        ['scope'] = {
+        ['scopesmall'] = {
             component = 'COMPONENT_AT_SCOPE_MACRO',
-            item = 'microsmg_scope',
+            item = 'microsmg_scopesmall',
         },
         ['suppressor'] = {
             component = 'COMPONENT_AT_AR_SUPP_02',
@@ -905,9 +905,9 @@ WeaponAttachments = {
             component = 'COMPONENT_AT_AR_FLSH',
             item = 'wep_flashlight',
         },
-        ['scope'] = {
+        ['scopesmall'] = {
             component = 'COMPONENT_AT_SCOPE_MACRO_02',
-            item = 'smg_scope',
+            item = 'smg_scopesmall',
         },
         ['suppressor'] = {
             component = 'COMPONENT_AT_PI_SUPP',
@@ -933,9 +933,9 @@ WeaponAttachments = {
             component = 'COMPONENT_AT_AR_FLSH',
             item = 'wep_flashlight',
         },
-        ['scope'] = {
+        ['scopesmall'] = {
             component = 'COMPONENT_AT_SCOPE_MACRO',
-            item = 'assaultsmg_scope',
+            item = 'assaultsmg_scopesmall',
         },
         ['suppressor'] = {
             component = 'COMPONENT_AT_AR_SUPP_02',
@@ -1015,9 +1015,9 @@ WeaponAttachments = {
             component = 'COMPONENT_AT_AR_AFGRIP',
             item = 'combatpdw_grip',
         },
-        ['scope'] = {
+        ['scopesmall'] = {
             component = 'COMPONENT_AT_SCOPE_SMALL',
-            item = 'combatpdw_scope',
+            item = 'combatpdw_scopesmall',
         },
     },
 	['WEAPON_SMG_MK2'] = {

--- a/config.lua
+++ b/config.lua
@@ -88,7 +88,6 @@ Config.DurabilityMultiplier = {
     ['weapon_combatpdw']             = 0.15,
     ['weapon_machinepistol']         = 0.15,
     ['weapon_minismg']               = 0.15,
-    ['weapon_raycarbine']            = 0.15,
 	['weapon_gusenberg']             = 0.15,
 	['weapon_tecpistol']             = 0.15,
 	
@@ -824,7 +823,7 @@ WeaponAttachments = {
             component = 'COMPONENT_CERAMICPISTOL_CLIP_02',
             item = 'ceramicppistol_extendedclip',
             type = 'clip',
-        },        
+        },
         ['suppressor'] = {
             component = 'COMPONENT_CERAMICPISTOL_SUPP',
             item = 'pistol_suppressor',
@@ -885,7 +884,7 @@ WeaponAttachments = {
             item = 'microsmg_luxuryfinish4',
         },
     },
-    ['WEAPON_SMG'] = { 
+    ['WEAPON_SMG'] = {
         ['defaultclip'] = {
             component = 'COMPONENT_SMG_CLIP_01',
             item = 'smg_defaultclip',

--- a/server/main.lua
+++ b/server/main.lua
@@ -359,7 +359,313 @@ QBCore.Functions.CreateUseableItem('weapontint_plat', function(source)
     TriggerClientEvent('weapons:client:EquipTint', source, 7)
 end)
 
+-- MK2 TINTS
+QBCore.Functions.CreateUseableItem('weapontint_mk2_classicblack', function(source)
+    TriggerClientEvent('weapons:client:EquipTint', source, 1)
+end)
+
+QBCore.Functions.CreateUseableItem('weapontint_mk2_classicgray', function(source)
+    TriggerClientEvent('weapons:client:EquipTint', source, 2)
+end)
+
+QBCore.Functions.CreateUseableItem('weapontint_mk2_classictwotone', function(source)
+    TriggerClientEvent('weapons:client:EquipTint', source, 3)
+end)
+
+QBCore.Functions.CreateUseableItem('weapontint_mk2_classicwhite', function(source)
+    TriggerClientEvent('weapons:client:EquipTint', source, 4)
+end)
+
+QBCore.Functions.CreateUseableItem('weapontint_mk2_classicbeige', function(source)
+    TriggerClientEvent('weapons:client:EquipTint', source, 5)
+end)
+
+QBCore.Functions.CreateUseableItem('weapontint_mk2_classicgreen', function(source)
+    TriggerClientEvent('weapons:client:EquipTint', source, 6)
+end)
+
+QBCore.Functions.CreateUseableItem('weapontint_mk2_classicblue', function(source)
+    TriggerClientEvent('weapons:client:EquipTint', source, 7)
+end)
+
+QBCore.Functions.CreateUseableItem('weapontint_mk2_classicearth', function(source)
+    TriggerClientEvent('weapons:client:EquipTint', source, 8)
+end)
+
+QBCore.Functions.CreateUseableItem('weapontint_mk2_classicbrownblack', function(source)
+    TriggerClientEvent('weapons:client:EquipTint', source, 9)
+end)
+
+QBCore.Functions.CreateUseableItem('weapontint_mk2_contrastred', function(source)
+    TriggerClientEvent('weapons:client:EquipTint', source, 10)
+end)
+
+QBCore.Functions.CreateUseableItem('weapontint_mk2_contrastblue', function(source)
+    TriggerClientEvent('weapons:client:EquipTint', source, 11)
+end)
+
+QBCore.Functions.CreateUseableItem('weapontint_mk2_contrastyellow', function(source)
+    TriggerClientEvent('weapons:client:EquipTint', source, 12)
+end)
+
+QBCore.Functions.CreateUseableItem('weapontint_mk2_contrastorange', function(source)
+    TriggerClientEvent('weapons:client:EquipTint', source, 13)
+end)
+
+QBCore.Functions.CreateUseableItem('weapontint_mk2_boldpink', function(source)
+    TriggerClientEvent('weapons:client:EquipTint', source, 14)
+end)
+
+QBCore.Functions.CreateUseableItem('weapontint_mk2_boldpurpleyellow', function(source)
+    TriggerClientEvent('weapons:client:EquipTint', source, 15)
+end)
+
+QBCore.Functions.CreateUseableItem('weapontint_mk2_boldorange', function(source)
+    TriggerClientEvent('weapons:client:EquipTint', source, 16)
+end)
+
+QBCore.Functions.CreateUseableItem('weapontint_mk2_boldgreenpurple', function(source)
+    TriggerClientEvent('weapons:client:EquipTint', source, 17)
+end)
+
+QBCore.Functions.CreateUseableItem('weapontint_mk2_boldredfeatures', function(source)
+    TriggerClientEvent('weapons:client:EquipTint', source, 18)
+end)
+
+QBCore.Functions.CreateUseableItem('weapontint_mk2_boldgreenfeatures', function(source)
+    TriggerClientEvent('weapons:client:EquipTint', source, 19)
+end)
+
+QBCore.Functions.CreateUseableItem('weapontint_mk2_boldcyanfeatures', function(source)
+    TriggerClientEvent('weapons:client:EquipTint', source, 20)
+end)
+
+QBCore.Functions.CreateUseableItem('weapontint_mk2_boldyellowfeatures', function(source)
+    TriggerClientEvent('weapons:client:EquipTint', source, 21)
+end)
+
+QBCore.Functions.CreateUseableItem('weapontint_mk2_boldredwhite', function(source)
+    TriggerClientEvent('weapons:client:EquipTint', source, 22)
+end)
+
+QBCore.Functions.CreateUseableItem('weapontint_mk2_boldredwhite', function(source)
+    TriggerClientEvent('weapons:client:EquipTint', source, 23)
+end)
+
+QBCore.Functions.CreateUseableItem('weapontint_mk2_boldbluewhite', function(source)
+    TriggerClientEvent('weapons:client:EquipTint', source, 24)
+end)
+
+QBCore.Functions.CreateUseableItem('weapontint_mk2_metallicgold', function(source)
+    TriggerClientEvent('weapons:client:EquipTint', source, 25)
+end)
+
+QBCore.Functions.CreateUseableItem('weapontint_mk2_metallicplatinum', function(source)
+    TriggerClientEvent('weapons:client:EquipTint', source, 26)
+end)
+
+QBCore.Functions.CreateUseableItem('weapontint_mk2_metallicgraylilac', function(source)
+    TriggerClientEvent('weapons:client:EquipTint', source, 27)
+end)
+
+QBCore.Functions.CreateUseableItem('weapontint_mk2_metallicpurplelime', function(source)
+    TriggerClientEvent('weapons:client:EquipTint', source, 28)
+end)
+
+QBCore.Functions.CreateUseableItem('weapontint_mk2_metallicred', function(source)
+    TriggerClientEvent('weapons:client:EquipTint', source, 29)
+end)
+
+QBCore.Functions.CreateUseableItem('weapontint_mk2_metallicgreen', function(source)
+    TriggerClientEvent('weapons:client:EquipTint', source, 30)
+end)
+
+QBCore.Functions.CreateUseableItem('weapontint_mk2_metallicblue', function(source)
+    TriggerClientEvent('weapons:client:EquipTint', source, 31)
+end)
+
+QBCore.Functions.CreateUseableItem('weapontint_mk2_metallicwhiteaqua', function(source)
+    TriggerClientEvent('weapons:client:EquipTint', source, 32)
+end)
+
+QBCore.Functions.CreateUseableItem('weapontint_mk2_metallicorangeaqua', function(source)
+    TriggerClientEvent('weapons:client:EquipTint', source, 33)
+end)
+
+QBCore.Functions.CreateUseableItem('weapontint_mk2_metallicorangeyellow', function(source)
+    TriggerClientEvent('weapons:client:EquipTint', source, 34)
+end)
+
+QBCore.Functions.CreateUseableItem('weapontint_mk2_metallicredyellow', function(source)
+    TriggerClientEvent('weapons:client:EquipTint', source, 35)
+end)
+
 -- ATTACHMENTS
+-- MELEE
+-- WEAPON_BAT
+QBCore.Functions.CreateUseableItem('bat_skin1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'wepskin1')
+end)
+
+QBCore.Functions.CreateUseableItem('bat_skin2', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'wepskin2')
+end)
+
+QBCore.Functions.CreateUseableItem('bat_skin3', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'wepskin3')
+end)
+
+QBCore.Functions.CreateUseableItem('bat_skin4', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'wepskin4')
+end)
+
+QBCore.Functions.CreateUseableItem('bat_skin5', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'wepskin5')
+end)
+
+QBCore.Functions.CreateUseableItem('bat_skin6', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'wepskin6')
+end)
+
+QBCore.Functions.CreateUseableItem('bat_skin7', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'wepskin7')
+end)
+
+QBCore.Functions.CreateUseableItem('bat_skin8', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'wepskin8')
+end)
+
+QBCore.Functions.CreateUseableItem('bat_skin9', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'wepskin9')
+end)
+
+QBCore.Functions.CreateUseableItem('bat_skin10', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'wepskin10')
+end)
+-- WEAPON_KNUCKLE
+QBCore.Functions.CreateUseableItem('knuckle_skin1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'wepskin1')
+end)
+
+QBCore.Functions.CreateUseableItem('knuckle_skin2', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'wepskin2')
+end)
+
+QBCore.Functions.CreateUseableItem('knuckle_skin3', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'wepskin3')
+end)
+
+QBCore.Functions.CreateUseableItem('knuckle_skin4', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'wepskin4')
+end)
+
+QBCore.Functions.CreateUseableItem('knuckle_skin5', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'wepskin5')
+end)
+
+QBCore.Functions.CreateUseableItem('knuckle_skin6', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'wepskin6')
+end)
+
+QBCore.Functions.CreateUseableItem('knuckle_skin7', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'wepskin7')
+end)
+
+QBCore.Functions.CreateUseableItem('knuckle_skin8', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'wepskin8')
+end)
+
+QBCore.Functions.CreateUseableItem('knuckle_skin9', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'wepskin9')
+end)
+
+QBCore.Functions.CreateUseableItem('knuckle_skin10', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'wepskin10')
+end)
+-- WEAPON_KNIFE
+QBCore.Functions.CreateUseableItem('knife_skin1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'wepskin1')
+end)
+
+QBCore.Functions.CreateUseableItem('knife_skin2', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'wepskin2')
+end)
+
+QBCore.Functions.CreateUseableItem('knife_skin3', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'wepskin3')
+end)
+
+QBCore.Functions.CreateUseableItem('knife_skin4', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'wepskin4')
+end)
+
+QBCore.Functions.CreateUseableItem('knife_skin5', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'wepskin5')
+end)
+
+QBCore.Functions.CreateUseableItem('knife_skin6', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'wepskin6')
+end)
+
+QBCore.Functions.CreateUseableItem('knife_skin7', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'wepskin7')
+end)
+
+QBCore.Functions.CreateUseableItem('knife_skin8', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'wepskin8')
+end)
+
+QBCore.Functions.CreateUseableItem('knife_skin9', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'wepskin9')
+end)
+
+QBCore.Functions.CreateUseableItem('knife_skin10', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'wepskin10')
+end)
+-- WEAPON_SWITCHBLADE
+QBCore.Functions.CreateUseableItem('switchblade_skin1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'wepskin1')
+end)
+
+QBCore.Functions.CreateUseableItem('switchblade_skin2', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'wepskin2')
+end)
+
+QBCore.Functions.CreateUseableItem('switchblade_skin3', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'wepskin3')
+end)
+
+-- SHARED ATTACHMENTS (ALL GUNS)
+QBCore.Functions.CreateUseableItem('wep_flashlight', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'flashlight')
+end)
+
+QBCore.Functions.CreateUseableItem('wep_compensator', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'compensator')
+end)
+
+QBCore.Functions.CreateUseableItem('pistol_suppressor', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'suppressor')
+end)
+
+QBCore.Functions.CreateUseableItem('smg_suppressor', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'suppressor')
+end)
+
+QBCore.Functions.CreateUseableItem('shotgun_suppressor', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'suppressor')
+end)
+
+QBCore.Functions.CreateUseableItem('rifle_suppressor', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'suppressor')
+end)
+
+QBCore.Functions.CreateUseableItem('sniper_suppressor', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'suppressor')
+end)
+
+-- PISTOLS
+-- WEAPON_PISTOL
 QBCore.Functions.CreateUseableItem('pistol_defaultclip', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
 end)
@@ -368,18 +674,10 @@ QBCore.Functions.CreateUseableItem('pistol_extendedclip', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
 end)
 
-QBCore.Functions.CreateUseableItem('pistol_flashlight', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'flashlight')
+QBCore.Functions.CreateUseableItem('pistol_luxuryfinish1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish1')
 end)
-
-QBCore.Functions.CreateUseableItem('pistol_suppressor', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'suppressor')
-end)
-
-QBCore.Functions.CreateUseableItem('pistol_luxuryfinish', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
-end)
-
+-- WEAPON_COMBATPISTOL
 QBCore.Functions.CreateUseableItem('combatpistol_defaultclip', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
 end)
@@ -388,10 +686,10 @@ QBCore.Functions.CreateUseableItem('combatpistol_extendedclip', function(source,
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
 end)
 
-QBCore.Functions.CreateUseableItem('combatpistol_luxuryfinish', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
+QBCore.Functions.CreateUseableItem('combatpistol_luxuryfinish1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish1')
 end)
-
+-- WEAPON_APPISTOL
 QBCore.Functions.CreateUseableItem('appistol_defaultclip', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
 end)
@@ -400,10 +698,14 @@ QBCore.Functions.CreateUseableItem('appistol_extendedclip', function(source, ite
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
 end)
 
-QBCore.Functions.CreateUseableItem('appistol_luxuryfinish', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
+QBCore.Functions.CreateUseableItem('appistol_luxuryfinish1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish1')
 end)
 
+QBCore.Functions.CreateUseableItem('appistol_luxuryfinish2', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish2')
+end)
+--WEAPON_PISTOL50
 QBCore.Functions.CreateUseableItem('pistol50_defaultclip', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
 end)
@@ -412,30 +714,10 @@ QBCore.Functions.CreateUseableItem('pistol50_extendedclip', function(source, ite
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
 end)
 
-QBCore.Functions.CreateUseableItem('pistol50_luxuryfinish', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
+QBCore.Functions.CreateUseableItem('pistol50_luxuryfinish1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish1')
 end)
-
-QBCore.Functions.CreateUseableItem('heavypistol_luxuryfinish', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
-end)
-
-QBCore.Functions.CreateUseableItem('revolver_defaultclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
-end)
-
-QBCore.Functions.CreateUseableItem('doubleaction_defaultclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
-end)
-
-QBCore.Functions.CreateUseableItem('revolver_vipvariant', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'vipvariant')
-end)
-
-QBCore.Functions.CreateUseableItem('revolver_bodyguardvariant', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'bodyguardvariant')
-end)
-
+--WEAPON_SNSPISTOL
 QBCore.Functions.CreateUseableItem('snspistol_defaultclip', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
 end)
@@ -444,10 +726,10 @@ QBCore.Functions.CreateUseableItem('snspistol_extendedclip', function(source, it
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
 end)
 
-QBCore.Functions.CreateUseableItem('snspistol_grip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'grip')
+QBCore.Functions.CreateUseableItem('snspistol_luxuryfinish1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish1')
 end)
-
+--WEAPON_HEAVYPISTOL
 QBCore.Functions.CreateUseableItem('heavypistol_defaultclip', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
 end)
@@ -456,10 +738,10 @@ QBCore.Functions.CreateUseableItem('heavypistol_extendedclip', function(source, 
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
 end)
 
-QBCore.Functions.CreateUseableItem('heavypistol_grip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'grip')
+QBCore.Functions.CreateUseableItem('heavypistol_luxuryfinish1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish1')
 end)
-
+--WEAPON_VINTAGEPISTOL
 QBCore.Functions.CreateUseableItem('vintagepistol_defaultclip', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
 end)
@@ -467,8 +749,290 @@ end)
 QBCore.Functions.CreateUseableItem('vintagepistol_extendedclip', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
 end)
+--WEAPON_REVOLVER
+QBCore.Functions.CreateUseableItem('revolver_luxuryfinish1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish1')
+end)
 
-QBCore.Functions.CreateUseableItem('combatpistol_defaultclip', function(source, item)
+QBCore.Functions.CreateUseableItem('revolver_luxuryfinish2', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish2')
+end)
+--WEAPON_PISTOL_MK2
+QBCore.Functions.CreateUseableItem('pistol_mk2_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('pistol_mk2_extendedclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
+end)
+
+QBCore.Functions.CreateUseableItem('pistol_mk2_luxuryfinish1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish1')
+end)
+
+QBCore.Functions.CreateUseableItem('pistol_mk2_luxuryfinish2', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish2')
+end)
+
+QBCore.Functions.CreateUseableItem('pistol_mk2_luxuryfinish3', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish3')
+end)
+
+QBCore.Functions.CreateUseableItem('pistol_mk2_luxuryfinish4', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish4')
+end)
+
+QBCore.Functions.CreateUseableItem('pistol_mk2_luxuryfinish5', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish5')
+end)
+
+QBCore.Functions.CreateUseableItem('pistol_mk2_luxuryfinish6', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish6')
+end)
+
+QBCore.Functions.CreateUseableItem('pistol_mk2_luxuryfinish7', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish7')
+end)
+
+QBCore.Functions.CreateUseableItem('pistol_mk2_luxuryfinish8', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish8')
+end)
+
+QBCore.Functions.CreateUseableItem('pistol_mk2_luxuryfinish9', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish9')
+end)
+
+QBCore.Functions.CreateUseableItem('pistol_mk2_luxuryfinish10', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish10')
+end)
+
+QBCore.Functions.CreateUseableItem('pistol_mk2_luxuryfinish11', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish11')
+end)
+
+QBCore.Functions.CreateUseableItem('pistol_mk2_luxuryfinish12', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish12')
+end)
+
+QBCore.Functions.CreateUseableItem('pistol_mk2_luxuryfinish13', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish13')
+end)
+
+QBCore.Functions.CreateUseableItem('pistol_mk2_luxuryfinish14', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish14')
+end)
+
+QBCore.Functions.CreateUseableItem('pistol_mk2_luxuryfinish15', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish15')
+end)
+
+QBCore.Functions.CreateUseableItem('pistol_mk2_luxuryfinish16', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish16')
+end)
+
+QBCore.Functions.CreateUseableItem('pistol_mk2_luxuryfinish17', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish17')
+end)
+
+QBCore.Functions.CreateUseableItem('pistol_mk2_luxuryfinish18', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish18')
+end)
+
+QBCore.Functions.CreateUseableItem('pistol_mk2_luxuryfinish19', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish19')
+end)
+
+QBCore.Functions.CreateUseableItem('pistol_mk2_luxuryfinish20', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish20')
+end)
+
+QBCore.Functions.CreateUseableItem('pistol_mk2_luxuryfinish21', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish21')
+end)
+
+QBCore.Functions.CreateUseableItem('pistol_mk2_luxuryfinish22', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish22')
+end)
+
+QBCore.Functions.CreateUseableItem('pistol_mk2_luxuryfinish23', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish23')
+end)
+
+QBCore.Functions.CreateUseableItem('pistol_mk2_luxuryfinish24', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish24')
+end)
+-- WEAPON_SNSPISTOL_MK2
+QBCore.Functions.CreateUseableItem('snspistol_mk2_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('snspistol_mk2_extendedclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
+end)
+
+QBCore.Functions.CreateUseableItem('snspistol_mk2_luxuryfinish1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish1')
+end)
+
+QBCore.Functions.CreateUseableItem('snspistol_mk2_luxuryfinish2', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish2')
+end)
+
+QBCore.Functions.CreateUseableItem('snspistol_mk2_luxuryfinish3', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish3')
+end)
+
+QBCore.Functions.CreateUseableItem('snspistol_mk2_luxuryfinish4', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish4')
+end)
+
+QBCore.Functions.CreateUseableItem('snspistol_mk2_luxuryfinish5', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish5')
+end)
+
+QBCore.Functions.CreateUseableItem('snspistol_mk2_luxuryfinish6', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish6')
+end)
+
+QBCore.Functions.CreateUseableItem('snspistol_mk2_luxuryfinish7', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish7')
+end)
+
+QBCore.Functions.CreateUseableItem('snspistol_mk2_luxuryfinish8', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish8')
+end)
+
+QBCore.Functions.CreateUseableItem('snspistol_mk2_luxuryfinish9', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish9')
+end)
+
+QBCore.Functions.CreateUseableItem('snspistol_mk2_luxuryfinish10', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish10')
+end)
+
+QBCore.Functions.CreateUseableItem('snspistol_mk2_luxuryfinish11', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish11')
+end)
+
+QBCore.Functions.CreateUseableItem('snspistol_mk2_luxuryfinish12', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish12')
+end)
+
+QBCore.Functions.CreateUseableItem('snspistol_mk2_luxuryfinish13', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish13')
+end)
+
+QBCore.Functions.CreateUseableItem('snspistol_mk2_luxuryfinish14', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish14')
+end)
+
+QBCore.Functions.CreateUseableItem('snspistol_mk2_luxuryfinish15', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish15')
+end)
+
+QBCore.Functions.CreateUseableItem('snspistol_mk2_luxuryfinish16', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish16')
+end)
+
+QBCore.Functions.CreateUseableItem('snspistol_mk2_luxuryfinish17', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish17')
+end)
+
+QBCore.Functions.CreateUseableItem('snspistol_mk2_luxuryfinish18', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish18')
+end)
+
+QBCore.Functions.CreateUseableItem('snspistol_mk2_luxuryfinish19', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish19')
+end)
+
+QBCore.Functions.CreateUseableItem('snspistol_mk2_luxuryfinish20', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish20')
+end)
+
+QBCore.Functions.CreateUseableItem('snspistol_mk2_luxuryfinish21', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish21')
+end)
+
+QBCore.Functions.CreateUseableItem('snspistol_mk2_luxuryfinish22', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish22')
+end)
+
+QBCore.Functions.CreateUseableItem('snspistol_mk2_luxuryfinish23', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish23')
+end)
+
+QBCore.Functions.CreateUseableItem('snspistol_mk2_luxuryfinish24', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish24')
+end)
+--WEAPON_REVOLVER_MK2
+QBCore.Functions.CreateUseableItem('revolver_mk2_scope', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scope')
+end)
+
+QBCore.Functions.CreateUseableItem('revolver_mk2_sight', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'holosight')
+end)
+
+QBCore.Functions.CreateUseableItem('revolver_mk2_luxuryfinish1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish1')
+end)
+
+QBCore.Functions.CreateUseableItem('revolver_mk2_luxuryfinish2', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish2')
+end)
+
+QBCore.Functions.CreateUseableItem('revolver_mk2_luxuryfinish3', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish3')
+end)
+
+QBCore.Functions.CreateUseableItem('revolver_mk2_luxuryfinish4', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish4')
+end)
+
+QBCore.Functions.CreateUseableItem('revolver_mk2_luxuryfinish5', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish5')
+end)
+
+QBCore.Functions.CreateUseableItem('revolver_mk2_luxuryfinish6', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish6')
+end)
+
+QBCore.Functions.CreateUseableItem('revolver_mk2_luxuryfinish7', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish7')
+end)
+
+QBCore.Functions.CreateUseableItem('revolver_mk2_luxuryfinish8', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish8')
+end)
+
+QBCore.Functions.CreateUseableItem('revolver_mk2_luxuryfinish9', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish9')
+end)
+
+QBCore.Functions.CreateUseableItem('revolver_mk2_luxuryfinish10', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish10')
+end)
+
+QBCore.Functions.CreateUseableItem('revolver_mk2_luxuryfinish11', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish11')
+end)
+--WEAPON_RAYPISTOL
+QBCore.Functions.CreateUseableItem('raypistol_luxuryfinish1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish1')
+end)
+--WEAPON_CERAMICPISTOL
+QBCore.Functions.CreateUseableItem('ceramicpistol_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('ceramicppistol_extendedclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
+end)
+
+-- SMGS
+-- WEAPON_MICROSMG
+QBCore.Functions.CreateUseableItem('microsmg_defaultclip', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
 end)
 
@@ -480,20 +1044,28 @@ QBCore.Functions.CreateUseableItem('microsmg_scope', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scope')
 end)
 
-QBCore.Functions.CreateUseableItem('microsmg_luxuryfinish', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
+QBCore.Functions.CreateUseableItem('microsmg_luxuryfinish1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish1')
 end)
 
+QBCore.Functions.CreateUseableItem('microsmg_luxuryfinish2', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish2')
+end)
+
+QBCore.Functions.CreateUseableItem('microsmg_luxuryfinish3', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish3')
+end)
+
+QBCore.Functions.CreateUseableItem('microsmg_luxuryfinish4', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish4')
+end)
+-- WEAPON_SMG
 QBCore.Functions.CreateUseableItem('smg_defaultclip', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
 end)
 
 QBCore.Functions.CreateUseableItem('smg_extendedclip', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
-end)
-
-QBCore.Functions.CreateUseableItem('smg_suppressor', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'suppressor')
 end)
 
 QBCore.Functions.CreateUseableItem('smg_drum', function(source, item)
@@ -504,10 +1076,10 @@ QBCore.Functions.CreateUseableItem('smg_scope', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scope')
 end)
 
-QBCore.Functions.CreateUseableItem('smg_luxuryfinish', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
+QBCore.Functions.CreateUseableItem('smg_luxuryfinish1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish1')
 end)
-
+-- WEAPON_ASSAULTSMG
 QBCore.Functions.CreateUseableItem('assaultsmg_defaultclip', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
 end)
@@ -516,18 +1088,22 @@ QBCore.Functions.CreateUseableItem('assaultsmg_extendedclip', function(source, i
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
 end)
 
-QBCore.Functions.CreateUseableItem('pumpshotgun_defaultclip', function(source, item)
+QBCore.Functions.CreateUseableItem('assaultsmg_scope', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scope')
+end)
+
+QBCore.Functions.CreateUseableItem('assaultsmg_luxuryfinish1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish1')
+end)
+-- WEAPON_GUSENBERG
+QBCore.Functions.CreateUseableItem('gusenberg_defaultclip', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
 end)
 
-QBCore.Functions.CreateUseableItem('sawnoffshotgun_defaultclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+QBCore.Functions.CreateUseableItem('gusenberg_extendedclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
 end)
-
-QBCore.Functions.CreateUseableItem('assaultsmg_luxuryfinish', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
-end)
-
+-- WEAPON_MINISMG
 QBCore.Functions.CreateUseableItem('minismg_defaultclip', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
 end)
@@ -535,7 +1111,7 @@ end)
 QBCore.Functions.CreateUseableItem('minismg_extendedclip', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
 end)
-
+-- WEAPON_MACHINEPISTOL
 QBCore.Functions.CreateUseableItem('machinepistol_defaultclip', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
 end)
@@ -547,7 +1123,7 @@ end)
 QBCore.Functions.CreateUseableItem('machinepistol_drum', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'drum')
 end)
-
+-- WEAPON_COMBATPDW
 QBCore.Functions.CreateUseableItem('combatpdw_defaultclip', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
 end)
@@ -556,50 +1132,153 @@ QBCore.Functions.CreateUseableItem('combatpdw_extendedclip', function(source, it
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
 end)
 
-QBCore.Functions.CreateUseableItem('combatpistol_defaultclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
-end)
-
-QBCore.Functions.CreateUseableItem('emplauncher_defaultclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
-end)
-
 QBCore.Functions.CreateUseableItem('combatpdw_drum', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'drum')
-end)
-
-QBCore.Functions.CreateUseableItem('combatpdw_grip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'grip')
 end)
 
 QBCore.Functions.CreateUseableItem('combatpdw_scope', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scope')
 end)
 
-QBCore.Functions.CreateUseableItem('shotgun_suppressor', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'suppressor')
+QBCore.Functions.CreateUseableItem('combatpdw_grip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'grip')
+end)
+-- WEAPON_SMG_MK2
+QBCore.Functions.CreateUseableItem('smg_mk2_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
 end)
 
-QBCore.Functions.CreateUseableItem('pumpshotgun_luxuryfinish', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
+QBCore.Functions.CreateUseableItem('smg_mk2_extendedclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
 end)
 
-QBCore.Functions.CreateUseableItem('sawnoffshotgun_luxuryfinish', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
+QBCore.Functions.CreateUseableItem('smg_mk2_scopesmall', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scopesmall')
 end)
 
-QBCore.Functions.CreateUseableItem('sniper_luxuryfinish', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
+QBCore.Functions.CreateUseableItem('smg_mk2_scopemedium', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scopemedium')
 end)
 
+QBCore.Functions.CreateUseableItem('smg_mk2_sight', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'holosight')
+end)
+
+QBCore.Functions.CreateUseableItem('smg_mk2_muzzle1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle1')
+end)
+
+QBCore.Functions.CreateUseableItem('smg_mk2_muzzle2', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle2')
+end)
+
+QBCore.Functions.CreateUseableItem('smg_mk2_muzzle3', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle3')
+end)
+
+QBCore.Functions.CreateUseableItem('smg_mk2_muzzle4', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle4')
+end)
+
+QBCore.Functions.CreateUseableItem('smg_mk2_muzzle5', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle5')
+end)
+
+QBCore.Functions.CreateUseableItem('smg_mk2_muzzle6', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle6')
+end)
+
+QBCore.Functions.CreateUseableItem('smg_mk2_muzzle7', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle7')
+end)
+
+QBCore.Functions.CreateUseableItem('smg_mk2_luxuryfinish1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish1')
+end)
+
+QBCore.Functions.CreateUseableItem('smg_mk2_luxuryfinish2', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish2')
+end)
+
+QBCore.Functions.CreateUseableItem('smg_mk2_luxuryfinish3', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish3')
+end)
+
+QBCore.Functions.CreateUseableItem('smg_mk2_luxuryfinish4', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish4')
+end)
+
+QBCore.Functions.CreateUseableItem('smg_mk2_luxuryfinish5', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish5')
+end)
+
+QBCore.Functions.CreateUseableItem('smg_mk2_luxuryfinish6', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish6')
+end)
+
+QBCore.Functions.CreateUseableItem('smg_mk2_luxuryfinish7', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish7')
+end)
+
+QBCore.Functions.CreateUseableItem('smg_mk2_luxuryfinish8', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish8')
+end)
+
+QBCore.Functions.CreateUseableItem('smg_mk2_luxuryfinish9', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish9')
+end)
+
+QBCore.Functions.CreateUseableItem('smg_mk2_luxuryfinish10', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish10')
+end)
+
+QBCore.Functions.CreateUseableItem('smg_mk2_luxuryfinish11', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish11')
+end)
+
+-- WEAPON_TECPISTOL
+QBCore.Functions.CreateUseableItem('tecpistol_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('tecpistol_extendedclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
+end)
+
+-- SHOTGUNS
+-- WEAPON_PUMPSHOTGUN
+QBCore.Functions.CreateUseableItem('pumpshotgun_luxuryfinish1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish1')
+end)
+
+QBCore.Functions.CreateUseableItem('pumpshotgun_luxuryfinish2', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish2')
+end)
+
+QBCore.Functions.CreateUseableItem('pumpshotgun_luxuryfinish3', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish3')
+end)
+-- WEAPON_SAWNOFFSHOTGUN
+QBCore.Functions.CreateUseableItem('sawnoffshotgun_luxuryfinish1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish1')
+end)
+-- WEAPON_ASSAULTSHOTGUN
 QBCore.Functions.CreateUseableItem('assaultshotgun_defaultclip', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
 end)
 
-QBCore.Functions.CreateUseableItem('assaultshotgun_extendedclip', function(source, item)
+QBCore.Functions.CreateUseableItem('assaultshotgun_drum', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
 end)
 
+QBCore.Functions.CreateUseableItem('assaultshotgun_grip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'grip')
+end)
+-- WEAPON_BULLPUPSHOTGUN
+QBCore.Functions.CreateUseableItem('bullpupshotgun_grip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'grip')
+end)
+-- WEAPON_HEAVYSHOTGUN
 QBCore.Functions.CreateUseableItem('heavyshotgun_defaultclip', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
 end)
@@ -612,6 +1291,72 @@ QBCore.Functions.CreateUseableItem('heavyshotgun_drum', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'drum')
 end)
 
+QBCore.Functions.CreateUseableItem('heavyshotgun_grip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'grip')
+end)
+-- WEAPON_PUMPSHOTGUN_MK2
+QBCore.Functions.CreateUseableItem('pumpshotgun_mk2_scopesmall', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scopesmall')
+end)
+
+QBCore.Functions.CreateUseableItem('pumpshotgun_mk2_scopemedium', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scopemedium')
+end)
+
+QBCore.Functions.CreateUseableItem('pumpshotgun_mk2_sight', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'holosight')
+end)
+
+QBCore.Functions.CreateUseableItem('pumpshotgun_mk2_muzzle1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle1')
+end)
+
+QBCore.Functions.CreateUseableItem('pumpshotgun_mk2_luxuryfinish1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish1')
+end)
+
+QBCore.Functions.CreateUseableItem('pumpshotgun_mk2_luxuryfinish2', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish2')
+end)
+
+QBCore.Functions.CreateUseableItem('pumpshotgun_mk2_luxuryfinish3', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish3')
+end)
+
+QBCore.Functions.CreateUseableItem('pumpshotgun_mk2_luxuryfinish4', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish4')
+end)
+
+QBCore.Functions.CreateUseableItem('pumpshotgun_mk2_luxuryfinish5', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish5')
+end)
+
+QBCore.Functions.CreateUseableItem('pumpshotgun_mk2_luxuryfinish6', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish6')
+end)
+
+QBCore.Functions.CreateUseableItem('pumpshotgun_mk2_luxuryfinish7', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish7')
+end)
+
+QBCore.Functions.CreateUseableItem('pumpshotgun_mk2_luxuryfinish8', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish8')
+end)
+
+QBCore.Functions.CreateUseableItem('pumpshotgun_mk2_luxuryfinish9', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish9')
+end)
+
+QBCore.Functions.CreateUseableItem('pumpshotgun_mk2_luxuryfinish10', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish10')
+end)
+
+QBCore.Functions.CreateUseableItem('pumpshotgun_mk2_luxuryfinish11', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish11')
+end)
+
+-- ASSAULT RIFLES
+-- WEAPON_ASSAULTRIFLE
 QBCore.Functions.CreateUseableItem('assaultrifle_defaultclip', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
 end)
@@ -624,26 +1369,18 @@ QBCore.Functions.CreateUseableItem('assaultrifle_drum', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'drum')
 end)
 
-QBCore.Functions.CreateUseableItem('rifle_flashlight', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'flashlight')
-end)
-
-QBCore.Functions.CreateUseableItem('rifle_grip', function(source, item)
+QBCore.Functions.CreateUseableItem('assaultrifle_grip', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'grip')
 end)
 
-QBCore.Functions.CreateUseableItem('rifle_suppressor', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'suppressor')
+QBCore.Functions.CreateUseableItem('assaultrifle_scopesmall', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scopesmall')
 end)
 
-QBCore.Functions.CreateUseableItem('sniperrifle_suppressor', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'suppressor')
+QBCore.Functions.CreateUseableItem('assaultrifle_luxuryfinish1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish1')
 end)
-
-QBCore.Functions.CreateUseableItem('assaultrifle_luxuryfinish', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
-end)
-
+--WEAPON_CARBINERIFLE
 QBCore.Functions.CreateUseableItem('carbinerifle_defaultclip', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
 end)
@@ -656,18 +1393,22 @@ QBCore.Functions.CreateUseableItem('carbinerifle_drum', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'drum')
 end)
 
-QBCore.Functions.CreateUseableItem('combatpdw_grip', function(source, item)
+QBCore.Functions.CreateUseableItem('carbinerifle_scopemedium', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scopemedium')
+end)
+
+QBCore.Functions.CreateUseableItem('carbinerifle_grip', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'grip')
 end)
 
-QBCore.Functions.CreateUseableItem('carbinerifle_scope', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scope')
+QBCore.Functions.CreateUseableItem('carbinerifle_luxuryfinish1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish1')
 end)
 
-QBCore.Functions.CreateUseableItem('carbinerifle_luxuryfinish', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
+QBCore.Functions.CreateUseableItem('carbinerifle_luxuryfinish2', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish2')
 end)
-
+-- WEAPON_ADVANCEDRIFLE
 QBCore.Functions.CreateUseableItem('advancedrifle_defaultclip', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
 end)
@@ -676,10 +1417,14 @@ QBCore.Functions.CreateUseableItem('advancedrifle_extendedclip', function(source
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
 end)
 
-QBCore.Functions.CreateUseableItem('advancedrifle_luxuryfinish', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
+QBCore.Functions.CreateUseableItem('advancedrifle_scopesmall', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scopesmall')
 end)
 
+QBCore.Functions.CreateUseableItem('advancedrifle_luxuryfinish1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish1')
+end)
+-- WEAPON_SPECIALCARBINE
 QBCore.Functions.CreateUseableItem('specialcarbine_defaultclip', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
 end)
@@ -688,18 +1433,22 @@ QBCore.Functions.CreateUseableItem('specialcarbine_extendedclip', function(sourc
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
 end)
 
-QBCore.Functions.CreateUseableItem('bullpupshotgun_defaultclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
-end)
-
 QBCore.Functions.CreateUseableItem('specialcarbine_drum', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'drum')
 end)
 
-QBCore.Functions.CreateUseableItem('specialcarbine_luxuryfinish', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
+QBCore.Functions.CreateUseableItem('specialcarbine_scopemedium', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scopemedium')
 end)
 
+QBCore.Functions.CreateUseableItem('specialcarbine_grip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'grip')
+end)
+
+QBCore.Functions.CreateUseableItem('specialcarbine_luxuryfinish1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish1')
+end)
+-- WEAPON_BULLPUPRIFLE
 QBCore.Functions.CreateUseableItem('bullpuprifle_defaultclip', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
 end)
@@ -708,10 +1457,18 @@ QBCore.Functions.CreateUseableItem('bullpuprifle_extendedclip', function(source,
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
 end)
 
-QBCore.Functions.CreateUseableItem('bullpuprifle_luxuryfinish', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
+QBCore.Functions.CreateUseableItem('bullpuprifle_scopesmall', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scopesmall')
 end)
 
+QBCore.Functions.CreateUseableItem('bullpuprifle_grip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'grip')
+end)
+
+QBCore.Functions.CreateUseableItem('bullpuprifle_luxuryfinish1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish1')
+end)
+-- WEAPON_COMPACTRIFLE
 QBCore.Functions.CreateUseableItem('compactrifle_defaultclip', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
 end)
@@ -723,47 +1480,623 @@ end)
 QBCore.Functions.CreateUseableItem('compactrifle_drum', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'drum')
 end)
-
-QBCore.Functions.CreateUseableItem('gusenberg_defaultclip', function(source, item)
+-- WEAPON_HEAVYRIFLE
+QBCore.Functions.CreateUseableItem('heavyrifle_defaultclip', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
 end)
 
-QBCore.Functions.CreateUseableItem('gusenberg_extendedclip', function(source, item)
+QBCore.Functions.CreateUseableItem('heavyrifle_extendedclip', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
 end)
 
-QBCore.Functions.CreateUseableItem('microsmg_defaultclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+QBCore.Functions.CreateUseableItem('heavyrifle_sight', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'holosight')
 end)
 
-QBCore.Functions.CreateUseableItem('microsmg_extendedclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
+QBCore.Functions.CreateUseableItem('heavyrifle_scopemedium', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scopemedium')
 end)
 
-QBCore.Functions.CreateUseableItem('sniperrifle_defaultclip', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
-end)
-
-QBCore.Functions.CreateUseableItem('sniper_scope', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scope')
-end)
-
-QBCore.Functions.CreateUseableItem('snipermax_scope', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scope')
-end)
-
-QBCore.Functions.CreateUseableItem('sniper_grip', function(source, item)
+QBCore.Functions.CreateUseableItem('heavyrifle_grip', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'grip')
 end)
 
-QBCore.Functions.CreateUseableItem('heavysniper_defaultclip', function(source, item)
+QBCore.Functions.CreateUseableItem('heavyrifle_luxuryfinish1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish1')
+end)
+-- WEAPON_ASSAULTRIFLE_MK2
+QBCore.Functions.CreateUseableItem('assaultrifle_mk2_defaultclip', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
 end)
 
-QBCore.Functions.CreateUseableItem('heavysniper_extendedclip', function(source, item)
+QBCore.Functions.CreateUseableItem('assaultrifle_mk2_extendedclip', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
 end)
 
+QBCore.Functions.CreateUseableItem('assaultrifle_mk2_grip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'grip')
+end)
+
+QBCore.Functions.CreateUseableItem('assaultrifle_mk2_sight', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'holosight')
+end)
+
+QBCore.Functions.CreateUseableItem('assaultrifle_mk2_scopesmall', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scopesmall')
+end)
+
+QBCore.Functions.CreateUseableItem('assaultrifle_mk2_scopelarge', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scopelarge')
+end)
+
+QBCore.Functions.CreateUseableItem('assaultrifle_mk2_muzzle1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle1')
+end)
+
+QBCore.Functions.CreateUseableItem('assaultrifle_mk2_muzzle2', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle2')
+end)
+
+QBCore.Functions.CreateUseableItem('assaultrifle_mk2_muzzle3', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle3')
+end)
+
+QBCore.Functions.CreateUseableItem('assaultrifle_mk2_muzzle4', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle4')
+end)
+
+QBCore.Functions.CreateUseableItem('assaultrifle_mk2_muzzle5', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle5')
+end)
+
+QBCore.Functions.CreateUseableItem('assaultrifle_mk2_muzzle6', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle6')
+end)
+
+QBCore.Functions.CreateUseableItem('assaultrifle_mk2_muzzle7', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle7')
+end)
+
+QBCore.Functions.CreateUseableItem('assaultrifle_mk2_barrel1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'barrel1')
+end)
+
+QBCore.Functions.CreateUseableItem('assaultrifle_mk2_barrel2', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'barrel2')
+end)
+
+QBCore.Functions.CreateUseableItem('assaultrifle_mk2_luxuryfinish1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish1')
+end)
+
+QBCore.Functions.CreateUseableItem('assaultrifle_mk2_luxuryfinish2', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish2')
+end)
+
+QBCore.Functions.CreateUseableItem('assaultrifle_mk2_luxuryfinish3', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish3')
+end)
+
+QBCore.Functions.CreateUseableItem('assaultrifle_mk2_luxuryfinish4', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish4')
+end)
+
+QBCore.Functions.CreateUseableItem('assaultrifle_mk2_luxuryfinish5', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish5')
+end)
+
+QBCore.Functions.CreateUseableItem('assaultrifle_mk2_luxuryfinish6', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish6')
+end)
+
+QBCore.Functions.CreateUseableItem('assaultrifle_mk2_luxuryfinish7', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish7')
+end)
+
+QBCore.Functions.CreateUseableItem('assaultrifle_mk2_luxuryfinish8', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish8')
+end)
+
+QBCore.Functions.CreateUseableItem('assaultrifle_mk2_luxuryfinish9', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish9')
+end)
+
+QBCore.Functions.CreateUseableItem('assaultrifle_mk2_luxuryfinish10', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish10')
+end)
+
+QBCore.Functions.CreateUseableItem('assaultrifle_mk2_luxuryfinish11', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish11')
+end)
+-- WEAPON_CARBINERIFLE_MK2
+QBCore.Functions.CreateUseableItem('carbinerifle_mk2_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('carbinerifle_mk2_extendedclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
+end)
+
+QBCore.Functions.CreateUseableItem('carbinerifle_mk2_grip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'grip')
+end)
+
+QBCore.Functions.CreateUseableItem('carbinerifle_mk2_sight', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'holosight')
+end)
+
+QBCore.Functions.CreateUseableItem('carbinerifle_mk2_scopesmall', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scopesmall')
+end)
+
+QBCore.Functions.CreateUseableItem('carbinerifle_mk2_scopelarge', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scopelarge')
+end)
+
+QBCore.Functions.CreateUseableItem('carbinerifle_mk2_muzzle1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle1')
+end)
+
+QBCore.Functions.CreateUseableItem('carbinerifle_mk2_muzzle2', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle2')
+end)
+
+QBCore.Functions.CreateUseableItem('carbinerifle_mk2_muzzle3', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle3')
+end)
+
+QBCore.Functions.CreateUseableItem('carbinerifle_mk2_muzzle4', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle4')
+end)
+
+QBCore.Functions.CreateUseableItem('carbinerifle_mk2_muzzle5', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle5')
+end)
+
+QBCore.Functions.CreateUseableItem('carbinerifle_mk2_muzzle6', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle6')
+end)
+
+QBCore.Functions.CreateUseableItem('carbinerifle_mk2_muzzle7', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle7')
+end)
+
+QBCore.Functions.CreateUseableItem('carbinerifle_mk2_barrel1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'barrel1')
+end)
+
+QBCore.Functions.CreateUseableItem('carbinerifle_mk2_barrel2', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'barrel2')
+end)
+
+QBCore.Functions.CreateUseableItem('carbinerifle_mk2_luxuryfinish1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish1')
+end)
+
+QBCore.Functions.CreateUseableItem('carbinerifle_mk2_luxuryfinish2', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish2')
+end)
+
+QBCore.Functions.CreateUseableItem('carbinerifle_mk2_luxuryfinish3', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish3')
+end)
+
+QBCore.Functions.CreateUseableItem('carbinerifle_mk2_luxuryfinish4', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish4')
+end)
+
+QBCore.Functions.CreateUseableItem('carbinerifle_mk2_luxuryfinish5', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish5')
+end)
+
+QBCore.Functions.CreateUseableItem('carbinerifle_mk2_luxuryfinish6', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish6')
+end)
+
+QBCore.Functions.CreateUseableItem('carbinerifle_mk2_luxuryfinish7', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish7')
+end)
+
+QBCore.Functions.CreateUseableItem('carbinerifle_mk2_luxuryfinish8', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish8')
+end)
+
+QBCore.Functions.CreateUseableItem('carbinerifle_mk2_luxuryfinish9', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish9')
+end)
+
+QBCore.Functions.CreateUseableItem('carbinerifle_mk2_luxuryfinish10', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish10')
+end)
+
+QBCore.Functions.CreateUseableItem('carbinerifle_mk2_luxuryfinish11', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish11')
+end)
+--WEAPON_SPECIALCARBINE_MK2
+QBCore.Functions.CreateUseableItem('specialcarbine_mk2_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('specialcarbine_mk2_extendedclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
+end)
+
+QBCore.Functions.CreateUseableItem('specialcarbine_mk2_grip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'grip')
+end)
+
+QBCore.Functions.CreateUseableItem('specialcarbine_mk2_sight', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'holosight')
+end)
+
+QBCore.Functions.CreateUseableItem('specialcarbine_mk2_scopesmall', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scopesmall')
+end)
+
+QBCore.Functions.CreateUseableItem('specialcarbine_mk2_scopelarge', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scopelarge')
+end)
+
+QBCore.Functions.CreateUseableItem('specialcarbine_mk2_muzzle1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle1')
+end)
+
+QBCore.Functions.CreateUseableItem('specialcarbine_mk2_muzzle2', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle2')
+end)
+
+QBCore.Functions.CreateUseableItem('specialcarbine_mk2_muzzle3', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle3')
+end)
+
+QBCore.Functions.CreateUseableItem('specialcarbine_mk2_muzzle4', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle4')
+end)
+
+QBCore.Functions.CreateUseableItem('specialcarbine_mk2_muzzle5', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle5')
+end)
+
+QBCore.Functions.CreateUseableItem('specialcarbine_mk2_muzzle6', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle6')
+end)
+
+QBCore.Functions.CreateUseableItem('specialcarbine_mk2_muzzle7', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle7')
+end)
+
+QBCore.Functions.CreateUseableItem('specialcarbine_mk2_barrel1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'barrel1')
+end)
+
+QBCore.Functions.CreateUseableItem('specialcarbine_mk2_barrel2', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'barrel2')
+end)
+
+QBCore.Functions.CreateUseableItem('specialcarbine_mk2_luxuryfinish1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish1')
+end)
+
+QBCore.Functions.CreateUseableItem('specialcarbine_mk2_luxuryfinish2', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish2')
+end)
+
+QBCore.Functions.CreateUseableItem('specialcarbine_mk2_luxuryfinish3', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish3')
+end)
+
+QBCore.Functions.CreateUseableItem('specialcarbine_mk2_luxuryfinish4', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish4')
+end)
+
+QBCore.Functions.CreateUseableItem('specialcarbine_mk2_luxuryfinish5', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish5')
+end)
+
+QBCore.Functions.CreateUseableItem('specialcarbine_mk2_luxuryfinish6', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish6')
+end)
+
+QBCore.Functions.CreateUseableItem('specialcarbine_mk2_luxuryfinish7', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish7')
+end)
+
+QBCore.Functions.CreateUseableItem('specialcarbine_mk2_luxuryfinish8', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish8')
+end)
+
+QBCore.Functions.CreateUseableItem('specialcarbine_mk2_luxuryfinish9', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish9')
+end)
+
+QBCore.Functions.CreateUseableItem('specialcarbine_mk2_luxuryfinish10', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish10')
+end)
+
+QBCore.Functions.CreateUseableItem('specialcarbine_mk2_luxuryfinish11', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish11')
+end)
+-- WEAPON_BULLPUPRIFLE_MK2
+QBCore.Functions.CreateUseableItem('bullpuprifle_mk2_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('bullpuprifle_mk2_extendedclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
+end)
+
+QBCore.Functions.CreateUseableItem('bullpuprifle_mk2_grip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'grip')
+end)
+
+QBCore.Functions.CreateUseableItem('bullpuprifle_mk2_sight', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'holosight')
+end)
+
+QBCore.Functions.CreateUseableItem('bullpuprifle_mk2_scopesmall', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scopesmall')
+end)
+
+QBCore.Functions.CreateUseableItem('bullpuprifle_mk2_scopemedium', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scopemedium')
+end)
+
+QBCore.Functions.CreateUseableItem('bullpuprifle_mk2_muzzle1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle1')
+end)
+
+QBCore.Functions.CreateUseableItem('bullpuprifle_mk2_muzzle2', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle2')
+end)
+
+QBCore.Functions.CreateUseableItem('bullpuprifle_mk2_muzzle3', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle3')
+end)
+
+QBCore.Functions.CreateUseableItem('bullpuprifle_mk2_muzzle4', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle4')
+end)
+
+QBCore.Functions.CreateUseableItem('bullpuprifle_mk2_muzzle5', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle5')
+end)
+
+QBCore.Functions.CreateUseableItem('bullpuprifle_mk2_muzzle6', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle6')
+end)
+
+QBCore.Functions.CreateUseableItem('bullpuprifle_mk2_muzzle7', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle7')
+end)
+
+QBCore.Functions.CreateUseableItem('bullpuprifle_mk2_barrel1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'barrel1')
+end)
+
+QBCore.Functions.CreateUseableItem('bullpuprifle_mk2_barrel2', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'barrel2')
+end)
+
+QBCore.Functions.CreateUseableItem('bullpuprifle_mk2_luxuryfinish1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish1')
+end)
+
+QBCore.Functions.CreateUseableItem('bullpuprifle_mk2_luxuryfinish2', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish2')
+end)
+
+QBCore.Functions.CreateUseableItem('bullpuprifle_mk2_luxuryfinish3', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish3')
+end)
+
+QBCore.Functions.CreateUseableItem('bullpuprifle_mk2_luxuryfinish4', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish4')
+end)
+
+QBCore.Functions.CreateUseableItem('bullpuprifle_mk2_luxuryfinish5', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish5')
+end)
+
+QBCore.Functions.CreateUseableItem('bullpuprifle_mk2_luxuryfinish6', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish6')
+end)
+
+QBCore.Functions.CreateUseableItem('bullpuprifle_mk2_luxuryfinish7', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish7')
+end)
+
+QBCore.Functions.CreateUseableItem('bullpuprifle_mk2_luxuryfinish8', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish8')
+end)
+
+QBCore.Functions.CreateUseableItem('bullpuprifle_mk2_luxuryfinish9', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish9')
+end)
+
+QBCore.Functions.CreateUseableItem('bullpuprifle_mk2_luxuryfinish10', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish10')
+end)
+
+QBCore.Functions.CreateUseableItem('bullpuprifle_mk2_luxuryfinish11', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish11')
+end)
+-- WEAPON_MILITARYRIFLE
+QBCore.Functions.CreateUseableItem('militaryrifle_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('militaryrifle_extendedclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
+end)
+
+QBCore.Functions.CreateUseableItem('militaryrifle_ironsights', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'ironsights')
+end)
+
+QBCore.Functions.CreateUseableItem('militaryrifle_scopesmall', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scopesmall')
+end)
+-- WEAPON_TACTICALRIFLE
+QBCore.Functions.CreateUseableItem('tacticalrifle_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('tacticalrifle_extendedclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
+end)
+
+-- LIGHT MACHINE GUNS
+-- WEAPON_MG
+QBCore.Functions.CreateUseableItem('mg_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('mg_extendedclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
+end)
+
+QBCore.Functions.CreateUseableItem('mg_scopesmall', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scopesmall')
+end)
+
+QBCore.Functions.CreateUseableItem('mg_luxuryfinish1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish1')
+end)
+-- WEAPON_COMBATMG
+QBCore.Functions.CreateUseableItem('combatmg_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('combatmg_extendedclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
+end)
+
+QBCore.Functions.CreateUseableItem('combatmg_scopemedium', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scopemedium')
+end)
+
+QBCore.Functions.CreateUseableItem('combatmg_grip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'grip')
+end)
+
+QBCore.Functions.CreateUseableItem('combatmg_luxuryfinish1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish1')
+end)
+-- WEAPON_COMBATMG_MK2
+QBCore.Functions.CreateUseableItem('combatmg_mk2_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('combatmg_mk2_extendedclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
+end)
+
+QBCore.Functions.CreateUseableItem('combatmg_mk2_sight', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'holosight')
+end)
+
+QBCore.Functions.CreateUseableItem('combatmg_mk2_scopemedium', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scopemedium')
+end)
+
+QBCore.Functions.CreateUseableItem('combatmg_mk2_scopelarge', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scopelarge')
+end)
+
+QBCore.Functions.CreateUseableItem('combatmg_mk2_muzzle1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle1')
+end)
+
+QBCore.Functions.CreateUseableItem('combatmg_mk2_muzzle2', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle2')
+end)
+
+QBCore.Functions.CreateUseableItem('combatmg_mk2_muzzle3', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle3')
+end)
+
+QBCore.Functions.CreateUseableItem('combatmg_mk2_muzzle4', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle4')
+end)
+
+QBCore.Functions.CreateUseableItem('combatmg_mk2_muzzle5', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle5')
+end)
+
+QBCore.Functions.CreateUseableItem('combatmg_mk2_muzzle6', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle6')
+end)
+
+QBCore.Functions.CreateUseableItem('combatmg_mk2_muzzle7', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle7')
+end)
+
+QBCore.Functions.CreateUseableItem('combatmg_mk2_barrel1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'barrel1')
+end)
+
+QBCore.Functions.CreateUseableItem('combatmg_mk2_barrel2', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'barrel2')
+end)
+
+QBCore.Functions.CreateUseableItem('combatmg_mk2_luxuryfinish1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish1')
+end)
+
+QBCore.Functions.CreateUseableItem('combatmg_mk2_luxuryfinish2', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish2')
+end)
+
+QBCore.Functions.CreateUseableItem('combatmg_mk2_luxuryfinish3', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish3')
+end)
+
+QBCore.Functions.CreateUseableItem('combatmg_mk2_luxuryfinish4', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish4')
+end)
+
+QBCore.Functions.CreateUseableItem('combatmg_mk2_luxuryfinish5', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish5')
+end)
+
+QBCore.Functions.CreateUseableItem('combatmg_mk2_luxuryfinish6', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish6')
+end)
+
+QBCore.Functions.CreateUseableItem('combatmg_mk2_luxuryfinish7', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish7')
+end)
+
+QBCore.Functions.CreateUseableItem('combatmg_mk2_luxuryfinish8', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish8')
+end)
+
+QBCore.Functions.CreateUseableItem('combatmg_mk2_luxuryfinish9', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish9')
+end)
+
+QBCore.Functions.CreateUseableItem('combatmg_mk2_luxuryfinish10', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish10')
+end)
+
+QBCore.Functions.CreateUseableItem('combatmg_mk2_luxuryfinish11', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish11')
+end)
+
+-- SNIPER RIFLES
+-- WEAPON_SNIPERRIFLE
+QBCore.Functions.CreateUseableItem('sniperrifle_scopemedium', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scopemedium')
+end)
+
+QBCore.Functions.CreateUseableItem('sniperrifle_scopelarge', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scopelarge')
+end)
+
+QBCore.Functions.CreateUseableItem('sniperrifle_luxuryfinish1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish1')
+end)
+-- WEAPON_MARKSMANRIFLE
 QBCore.Functions.CreateUseableItem('marksmanrifle_defaultclip', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
 end)
@@ -772,14 +2105,192 @@ QBCore.Functions.CreateUseableItem('marksmanrifle_extendedclip', function(source
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
 end)
 
-QBCore.Functions.CreateUseableItem('marksmanrifle_scope', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scope')
+QBCore.Functions.CreateUseableItem('marksmanrifle_scopelarge', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scopelarge')
 end)
 
-QBCore.Functions.CreateUseableItem('marksmanrifle_luxuryfinish', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
+QBCore.Functions.CreateUseableItem('marksmanrifle_grip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'grip')
 end)
 
-QBCore.Functions.CreateUseableItem('snspistol_luxuryfinish', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish')
+QBCore.Functions.CreateUseableItem('marksmanrifle_luxuryfinish1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish1')
+end)
+-- WEAPON_HEAVYSNIPER_MK2
+QBCore.Functions.CreateUseableItem('heavysniper_mk2_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('heavysniper_mk2_extendedclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
+end)
+
+QBCore.Functions.CreateUseableItem('heavysniper_mk2_scopelarge', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scopelarge')
+end)
+
+QBCore.Functions.CreateUseableItem('heavysniper_mk2_muzzle1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle1')
+end)
+
+QBCore.Functions.CreateUseableItem('heavysniper_mk2_muzzle2', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle2')
+end)
+
+QBCore.Functions.CreateUseableItem('heavysniper_mk2_barrel1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'barrel1')
+end)
+
+QBCore.Functions.CreateUseableItem('heavysniper_mk2_barrel2', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'barrel2')
+end)
+
+QBCore.Functions.CreateUseableItem('heavysniper_mk2_luxuryfinish1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish1')
+end)
+
+QBCore.Functions.CreateUseableItem('heavysniper_mk2_luxuryfinish2', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish2')
+end)
+
+QBCore.Functions.CreateUseableItem('heavysniper_mk2_luxuryfinish3', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish3')
+end)
+
+QBCore.Functions.CreateUseableItem('heavysniper_mk2_luxuryfinish4', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish4')
+end)
+
+QBCore.Functions.CreateUseableItem('heavysniper_mk2_luxuryfinish5', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish5')
+end)
+
+QBCore.Functions.CreateUseableItem('heavysniper_mk2_luxuryfinish6', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish6')
+end)
+
+QBCore.Functions.CreateUseableItem('heavysniper_mk2_luxuryfinish7', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish7')
+end)
+
+QBCore.Functions.CreateUseableItem('heavysniper_mk2_luxuryfinish8', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish8')
+end)
+
+QBCore.Functions.CreateUseableItem('heavysniper_mk2_luxuryfinish9', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish9')
+end)
+
+QBCore.Functions.CreateUseableItem('heavysniper_mk2_luxuryfinish10', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish10')
+end)
+
+QBCore.Functions.CreateUseableItem('heavysniper_mk2_luxuryfinish11', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish11')
+end)
+-- WEAPON_MARKSMANRIFLE_MK2
+QBCore.Functions.CreateUseableItem('marksmanrifle_mk2_defaultclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'defaultclip')
+end)
+
+QBCore.Functions.CreateUseableItem('marksmanrifle_mk2_extendedclip', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
+end)
+
+QBCore.Functions.CreateUseableItem('marksmanrifle_mk2_sight', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'holosight')
+end)
+
+QBCore.Functions.CreateUseableItem('marksmanrifle_mk2_scopemedium', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scopemedium')
+end)
+
+QBCore.Functions.CreateUseableItem('marksmanrifle_mk2_scopelarge', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scopelarge')
+end)
+
+QBCore.Functions.CreateUseableItem('marksmanrifle_mk2_muzzle1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle1')
+end)
+
+QBCore.Functions.CreateUseableItem('marksmanrifle_mk2_muzzle2', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle2')
+end)
+
+QBCore.Functions.CreateUseableItem('marksmanrifle_mk2_muzzle3', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle3')
+end)
+
+QBCore.Functions.CreateUseableItem('marksmanrifle_mk2_muzzle4', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle4')
+end)
+
+QBCore.Functions.CreateUseableItem('marksmanrifle_mk2_muzzle5', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle5')
+end)
+
+QBCore.Functions.CreateUseableItem('marksmanrifle_mk2_muzzle6', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle6')
+end)
+
+QBCore.Functions.CreateUseableItem('marksmanrifle_mk2_muzzle7', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'muzzle7')
+end)
+
+QBCore.Functions.CreateUseableItem('marksmanrifle_mk2_barrel1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'barrel1')
+end)
+
+QBCore.Functions.CreateUseableItem('marksmanrifle_mk2_barrel2', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'barrel2')
+end)
+
+QBCore.Functions.CreateUseableItem('marksmanrifle_mk2_luxuryfinish1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish1')
+end)
+
+QBCore.Functions.CreateUseableItem('marksmanrifle_mk2_luxuryfinish2', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish2')
+end)
+
+QBCore.Functions.CreateUseableItem('marksmanrifle_mk2_luxuryfinish3', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish3')
+end)
+
+QBCore.Functions.CreateUseableItem('marksmanrifle_mk2_luxuryfinish4', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish4')
+end)
+
+QBCore.Functions.CreateUseableItem('marksmanrifle_mk2_luxuryfinish5', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish5')
+end)
+
+QBCore.Functions.CreateUseableItem('marksmanrifle_mk2_luxuryfinish6', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish6')
+end)
+
+QBCore.Functions.CreateUseableItem('marksmanrifle_mk2_luxuryfinish7', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish7')
+end)
+
+QBCore.Functions.CreateUseableItem('marksmanrifle_mk2_luxuryfinish8', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish8')
+end)
+
+QBCore.Functions.CreateUseableItem('marksmanrifle_mk2_luxuryfinish9', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish9')
+end)
+
+QBCore.Functions.CreateUseableItem('marksmanrifle_mk2_luxuryfinish10', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish10')
+end)
+
+QBCore.Functions.CreateUseableItem('marksmanrifle_mk2_luxuryfinish11', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish11')
+end)
+
+-- HEAVY WEAPONS
+-- WEAPON_RPG
+QBCore.Functions.CreateUseableItem('rpg_luxuryfinish1', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish1')
 end)

--- a/server/main.lua
+++ b/server/main.lua
@@ -870,6 +870,10 @@ QBCore.Functions.CreateUseableItem('snspistol_mk2_extendedclip', function(source
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
 end)
 
+QBCore.Functions.CreateUseableItem('snspistol_mk2_scopesmall', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scopesmall')
+end)
+
 QBCore.Functions.CreateUseableItem('snspistol_mk2_luxuryfinish1', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish1')
 end)
@@ -966,8 +970,8 @@ QBCore.Functions.CreateUseableItem('snspistol_mk2_luxuryfinish24', function(sour
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'luxuryfinish24')
 end)
 --WEAPON_REVOLVER_MK2
-QBCore.Functions.CreateUseableItem('revolver_mk2_scope', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scope')
+QBCore.Functions.CreateUseableItem('revolver_mk2_scopesmall', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scopesmall')
 end)
 
 QBCore.Functions.CreateUseableItem('revolver_mk2_sight', function(source, item)
@@ -1040,8 +1044,8 @@ QBCore.Functions.CreateUseableItem('microsmg_extendedclip', function(source, ite
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
 end)
 
-QBCore.Functions.CreateUseableItem('microsmg_scope', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scope')
+QBCore.Functions.CreateUseableItem('microsmg_scopesmall', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scopesmall')
 end)
 
 QBCore.Functions.CreateUseableItem('microsmg_luxuryfinish1', function(source, item)
@@ -1072,8 +1076,8 @@ QBCore.Functions.CreateUseableItem('smg_drum', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'drum')
 end)
 
-QBCore.Functions.CreateUseableItem('smg_scope', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scope')
+QBCore.Functions.CreateUseableItem('smg_scopesmall', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scopesmall')
 end)
 
 QBCore.Functions.CreateUseableItem('smg_luxuryfinish1', function(source, item)
@@ -1088,8 +1092,8 @@ QBCore.Functions.CreateUseableItem('assaultsmg_extendedclip', function(source, i
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'extendedclip')
 end)
 
-QBCore.Functions.CreateUseableItem('assaultsmg_scope', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scope')
+QBCore.Functions.CreateUseableItem('assaultsmg_scopesmall', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scopesmall')
 end)
 
 QBCore.Functions.CreateUseableItem('assaultsmg_luxuryfinish1', function(source, item)
@@ -1136,8 +1140,8 @@ QBCore.Functions.CreateUseableItem('combatpdw_drum', function(source, item)
     TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'drum')
 end)
 
-QBCore.Functions.CreateUseableItem('combatpdw_scope', function(source, item)
-    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scope')
+QBCore.Functions.CreateUseableItem('combatpdw_scopesmall', function(source, item)
+    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'scopesmall')
 end)
 
 QBCore.Functions.CreateUseableItem('combatpdw_grip', function(source, item)


### PR DESCRIPTION
**Describe Pull request**
This update adds all missing weapon attachment components, MK2 tints, including consolidation of some shared parts like flashlight, compensators, muzzles etc. This also allocates some missing DLC weapons. This PR will require the following PR's to be merged in to support recoil, weapon draw, ambulance death type and inventory images.

I have personally spawned in each weapon, component, tint and skin and applied them to the weapon.

If your PR is to fix an issue mention that issue here
https://github.com/qbcore-framework/qb-ambulancejob/pull/305
https://github.com/qbcore-framework/qb-core/pull/1000
https://github.com/qbcore-framework/qb-inventory/pull/447
https://github.com/qbcore-framework/qb-smallresources/pull/390

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? Yes (Latest build as of 09/07/2023)
- Does your code fit the style guidelines? I believe so, just let me know if it doesn't and I will adjust.
- Does your PR fit the contribution guidelines? Yes

**Additional notes:**
1. When applying skins/tints to weapons, it seems these apply to the weapon and save in the DB JSON for inventory, I believe some work may be needed to force the return and/or removal of previous skin/tint before a new one is applied, maybe this could be configurable so you can choose if a tint/skin removes or gives the player back the item. I'm not able to enable this change so would be happy to get assistance for this.

2. Currently the server\main.lua uses the older **QBCore.Functions.CreateUsableItem** function, it would be good to change this so it loops through the table based in the config.lua file, like the change that was done with consumables in qb-smallresources. I'm again not 100% how to achieve this noting the above, so it would be great if someone wants to look into that side of it and we can merge that in with this PR. This will save people time maintaining it and adding new items, also brings it in-line with how it's done in other QB resources.

`QBCore.Functions.CreateUseableItem('bat_skin1', function(source, item)
    TriggerClientEvent('weapons:client:EquipAttachment', source, item, 'wepskin1')
end)`

A potential fix for tints could be handled by setting the index back to 0 as per nevaRaven's example:
https://discord.com/channels/831626422232678481/1126449634773045290


