### PR TITLE
Removed slot check from removeWeaponAmmoItem event

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -286,9 +286,9 @@ end)
 RegisterNetEvent('weapons:server:removeWeaponAmmoItem', function(item)
     local Player = QBCore.Functions.GetPlayer(source)
 
-    if not Player or type(item) ~= 'table' or not item.name or not item.slot then return end
+    if not Player or type(item) ~= 'table' or not item.name then return end
 
-    Player.Functions.RemoveItem(item.name, 1, item.slot)
+    Player.Functions.RemoveItem(item.name, 1)
 end)
 
 -- Commands


### PR DESCRIPTION
Removed the or not item.slot from the if and removed the item.slot from the removeItem function. Because it is pointless

**Describe Pull request**
I have removed the slot check from the weapons:server:removeWeaponAmmoItem event because i see no reason why it is there, it just makes it hard for people that want to use the event to remove the item, since you need to give it the itemData from the inventory and not QBCore.Shared.Items

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? Yes it works fine
- Does your code fit the style guidelines? Yes
- Does your PR fit the contribution guidelines? Yes
