### PR TITLE
fix: prevent reload if weapon switched to incorrect ammo

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -101,8 +101,8 @@ RegisterNetEvent('qb-weapons:client:AddAmmo', function(ammoType, amount, itemDat
     }, {}, {}, {}, function() -- Done
         weapon = GetSelectedPedWeapon(ped) -- Get weapon at time of completion
 
-        if QBCore.Shared.Weapons[weapon]?.ammotype ~= ammoType then 
-            return QBCore.Functions.Notify(Lang:t('error.wrong_ammo'), 'error') 
+        if QBCore.Shared.Weapons[weapon]?.ammotype ~= ammoType then
+            return QBCore.Functions.Notify(Lang:t('error.wrong_ammo'), 'error')
         end
 
         AddAmmoToPed(ped, weapon, amount)

--- a/client/main.lua
+++ b/client/main.lua
@@ -66,7 +66,7 @@ RegisterNetEvent('qb-weapons:client:SetWeaponQuality', function(amount)
     end
 end)
 
-RegisterNetEvent('qb-weapons:client:AddAmmo', function(type, amount, itemData)
+RegisterNetEvent('qb-weapons:client:AddAmmo', function(ammoType, amount, itemData)
     local ped = PlayerPedId()
     local weapon = GetSelectedPedWeapon(ped)
 
@@ -80,7 +80,7 @@ RegisterNetEvent('qb-weapons:client:AddAmmo', function(type, amount, itemData)
         return
     end
 
-    if QBCore.Shared.Weapons[weapon]['ammotype'] ~= type:upper() then
+    if QBCore.Shared.Weapons[weapon]['ammotype'] ~= ammoType:upper() then
         QBCore.Functions.Notify(Lang:t('error.wrong_ammo'), 'error')
         return
     end
@@ -99,14 +99,18 @@ RegisterNetEvent('qb-weapons:client:AddAmmo', function(type, amount, itemData)
         disableMouse = false,
         disableCombat = true,
     }, {}, {}, {}, function() -- Done
-        if QBCore.Shared.Weapons[weapon] then
-            AddAmmoToPed(ped, weapon, amount)
-            TaskReloadWeapon(ped, false)
-            TriggerServerEvent('qb-weapons:server:UpdateWeaponAmmo', CurrentWeaponData, total + amount)
-            TriggerServerEvent('qb-weapons:server:removeWeaponAmmoItem', itemData)
-            TriggerEvent('qb-inventory:client:ItemBox', QBCore.Shared.Items[itemData.name], 'remove')
-            TriggerEvent('QBCore:Notify', Lang:t('success.reloaded'), 'success')
+        weapon = GetSelectedPedWeapon(ped) -- Get weapon at time of completion
+
+        if QBCore.Shared.Weapons[weapon]?.ammotype ~= ammoType then 
+            return QBCore.Functions.Notify(Lang:t('error.wrong_ammo'), 'error') 
         end
+
+        AddAmmoToPed(ped, weapon, amount)
+        TaskReloadWeapon(ped, false)
+        TriggerServerEvent('qb-weapons:server:UpdateWeaponAmmo', CurrentWeaponData, total + amount)
+        TriggerServerEvent('qb-weapons:server:removeWeaponAmmoItem', itemData)
+        TriggerEvent('qb-inventory:client:ItemBox', QBCore.Shared.Items[itemData.name], 'remove')
+        TriggerEvent('QBCore:Notify', Lang:t('success.reloaded'), 'success')
     end, function()
         QBCore.Functions.Notify(Lang:t('error.canceled'), 'error')
     end)


### PR DESCRIPTION
**Describe Pull request**
This PR checks the ammo type on the progressbar completion callback, without this you are able to switch weapon during the progress bar which will result in the metadata of the incorrect weapon and item being set and increasing the ammo. This is abusable by beginning to reload a pistol with pistol ammo and switching to an assault rifle as the assault rifle will then gain ammo when pulling the weapon back out.

This PR fixes the issue https://github.com/qbcore-framework/qb-inventory/issues/574

**Questions (please complete the following information):**
- [x] Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest)
- [x] Does your code fit the style guidelines? [yes/no]
- [x] Does your PR fit the contribution guidelines? [yes/no]
