### PR TITLE
Round weapon quality to two decimal points to avoid rounding issues

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -164,7 +164,7 @@ RegisterNetEvent('qb-weapons:server:UpdateWeaponQuality', function(data, RepeatA
             if WeaponSlot.info.quality then
                 for _ = 1, RepeatAmount, 1 do
                     if WeaponSlot.info.quality - DecreaseAmount > 0 then
-                        WeaponSlot.info.quality = WeaponSlot.info.quality - DecreaseAmount
+                        WeaponSlot.info.quality = QBCore.Shared.Round(WeaponSlot.info.quality - DecreaseAmount, 2)
                     else
                         WeaponSlot.info.quality = 0
                         TriggerClientEvent('qb-weapons:client:UseWeapon', src, data, false)
@@ -176,7 +176,7 @@ RegisterNetEvent('qb-weapons:server:UpdateWeaponQuality', function(data, RepeatA
                 WeaponSlot.info.quality = 100
                 for _ = 1, RepeatAmount, 1 do
                     if WeaponSlot.info.quality - DecreaseAmount > 0 then
-                        WeaponSlot.info.quality = WeaponSlot.info.quality - DecreaseAmount
+                        WeaponSlot.info.quality = QBCore.Shared.Round(WeaponSlot.info.quality - DecreaseAmount, 2)
                     else
                         WeaponSlot.info.quality = 0
                         TriggerClientEvent('qb-weapons:client:UseWeapon', src, data, false)


### PR DESCRIPTION
**Describe Pull request**
I noticed that the quality of weapons grows to a huge amount of decimal points so I updated the calculations to round to two decimal points.

Before:
![image](https://github.com/user-attachments/assets/4ec6d2ce-9e62-4cc4-8ea4-b58908ca9419)

After:
![image](https://github.com/user-attachments/assets/b9d35c42-ec61-4556-901d-5d0ae1842fab)

**Questions (please complete the following information):**
- [x] Have you personally loaded this code into an updated qbcore project and checked all it's functionality?
- [x] Does your code fit the style guidelines?
- [x] Does your PR fit the contribution guidelines? 