### PR TITLE
Move Ammo Types into the Config instead of server.lua

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -9,6 +9,16 @@ Config.DurabilityBlockedWeapons = {
     'weapon_unarmed',
 }
 
+Config.AmmoTypes = {
+    pistol_ammo = { ammoType = 'AMMO_PISTOL', amount = 30 },
+    rifle_ammo = { ammoType = 'AMMO_RIFLE', amount = 30 },
+    smg_ammo = { ammoType = 'AMMO_SMG', amount = 30 },
+    shotgun_ammo = { ammoType = 'AMMO_SHOTGUN', amount = 10 },
+    mg_ammo = { ammoType = 'AMMO_MG', amount = 30 },
+    snp_ammo = { ammoType = 'AMMO_SNIPER', amount = 10 },
+    emp_ammo = { ammoType = 'AMMO_EMPLAUNCHER', amount = 10 },
+}
+
 Config.Throwables = {
     'ball',
     'bzgas',

--- a/server/main.lua
+++ b/server/main.lua
@@ -205,17 +205,7 @@ end, 'god')
 -- Items
 
 -- AMMO
-local AmmoTypes = {
-    pistol_ammo = { ammoType = 'AMMO_PISTOL', amount = 30 },
-    rifle_ammo = { ammoType = 'AMMO_RIFLE', amount = 30 },
-    smg_ammo = { ammoType = 'AMMO_SMG', amount = 30 },
-    shotgun_ammo = { ammoType = 'AMMO_SHOTGUN', amount = 10 },
-    mg_ammo = { ammoType = 'AMMO_MG', amount = 30 },
-    snp_ammo = { ammoType = 'AMMO_SNIPER', amount = 10 },
-    emp_ammo = { ammoType = 'AMMO_EMPLAUNCHER', amount = 10 }
-}
-
-for ammoItem, properties in pairs(AmmoTypes) do
+for ammoItem, properties in pairs(Config.AmmoTypes) do
     QBCore.Functions.CreateUseableItem(ammoItem, function(source, item)
         TriggerClientEvent('qb-weapons:client:AddAmmo', source, properties.ammoType, properties.amount, item)
     end)


### PR DESCRIPTION
**Describe Pull request**
Move ammo types out of the server.lua and into the config

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? yes
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
