### PR TITLE
slowed loops if you dont have a weapon

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -183,6 +183,7 @@ CreateThread(function()
     SetWeaponsNoAutoswap(true)
 end)
 
+
 CreateThread(function()
     while true do
         local ped = PlayerPedId()
@@ -194,8 +195,10 @@ CreateThread(function()
                 TriggerServerEvent('qb-weapons:server:UpdateWeaponQuality', CurrentWeaponData, MultiplierAmount)
                 MultiplierAmount = 0
             end
+            Wait(0)
+        else
+            Wait(1500)
         end
-        Wait(0)
     end
 end)
 
@@ -222,9 +225,11 @@ CreateThread(function()
                         end
                     end
                 end
+                Wait(0)
+            else
+                Wait(1000)
             end
         end
-        Wait(0)
     end
 end)
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -187,17 +187,19 @@ end)
 CreateThread(function()
     while true do
         local ped = PlayerPedId()
-        if IsPedArmed(ped, 7) == 1 and (IsControlJustReleased(0, 24) or IsDisabledControlJustReleased(0, 24)) then
-            local weapon = GetSelectedPedWeapon(ped)
-            local ammo = GetAmmoInPedWeapon(ped, weapon)
-            TriggerServerEvent('qb-weapons:server:UpdateWeaponAmmo', CurrentWeaponData, tonumber(ammo))
-            if MultiplierAmount > 0 then
-                TriggerServerEvent('qb-weapons:server:UpdateWeaponQuality', CurrentWeaponData, MultiplierAmount)
-                MultiplierAmount = 0
+        if GetSelectedPedWeapon(ped) ~= `WEAPON_UNARMED` then
+            if IsPedArmed(ped, 7) == 1 and (IsControlJustReleased(0, 24) or IsDisabledControlJustReleased(0, 24)) then
+                local weapon = GetSelectedPedWeapon(ped)
+                local ammo = GetAmmoInPedWeapon(ped, weapon)
+                TriggerServerEvent('qb-weapons:server:UpdateWeaponAmmo', CurrentWeaponData, tonumber(ammo))
+                if MultiplierAmount > 0 then
+                    TriggerServerEvent('qb-weapons:server:UpdateWeaponQuality', CurrentWeaponData, MultiplierAmount)
+                    MultiplierAmount = 0
+                end
             end
             Wait(0)
         else
-            Wait(1500)
+            Wait(1000)
         end
     end
 end)
@@ -230,6 +232,7 @@ CreateThread(function()
                 Wait(1000)
             end
         end
+       Wait(1)
     end
 end)
 


### PR DESCRIPTION
I put a wait(1500) if unarmed
and a 1000 if there isnt CurrentWeaponData

this slows down the loops running while not using a weapon and gave less of a wait than a typical weapondraw animation so this should have minimal blowbacks for the 1.5 seconds it may miss

on my personal computer it took client side resmon down from 0.04 to 0.00 on idle

**Describe Pull request**
stop making loops go brrrr and make them slower when not needed and kept original speed when needed

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
