### PR TITLE
Update weapdraw.lua

### DIFF
--- a/client/weapdraw.lua
+++ b/client/weapdraw.lua
@@ -102,7 +102,6 @@ local weapons = {
     'WEAPON_STONE_HATCHET'
 }
 
-local canFire = true
 local currHolsterTexture = nil
 
 local function loadAnimDict(dict)
@@ -144,7 +143,7 @@ RegisterNetEvent('qb-weapons:client:DrawWeapon', function()
     if GetResourceState('qb-inventory') == 'missing' then return end
 
     local ped, currWeap = PlayerPedId(), `WEAPON_UNARMED`
-    local holstered, canFire = true, true
+    local holstered = true
 
     while true do
         Wait(250)

--- a/client/weapdraw.lua
+++ b/client/weapdraw.lua
@@ -113,10 +113,6 @@ local function loadAnimDict(dict)
     end
 end
 
-local function isPlayingAnim(ped, dict, anim)
-    return IsEntityPlayingAnim(ped, dict, anim, 3)
-end
-
 local function checkWeapon(newWeap)
     for i = 1, #weapons do
         if joaat(weapons[i]) == newWeap then

--- a/client/weapdraw.lua
+++ b/client/weapdraw.lua
@@ -113,6 +113,10 @@ local function loadAnimDict(dict)
     end
 end
 
+local function isPlayingAnim(ped, dict, anim)
+    return IsEntityPlayingAnim(ped, dict, anim, 3)
+end
+
 local function checkWeapon(newWeap)
     for i = 1, #weapons do
         if joaat(weapons[i]) == newWeap then
@@ -143,64 +147,69 @@ end)
 RegisterNetEvent('qb-weapons:client:DrawWeapon', function()
     if GetResourceState('qb-inventory') == 'missing' then return end
 
-    local ped, currWeap = PlayerPedId(), `WEAPON_UNARMED`
+    local ped = PlayerPedId()
+    local currWeap = `WEAPON_UNARMED`
     local holstered = true
+    local canFire = true
+
+    loadAnimDict('rcmjosh4')
+    loadAnimDict('reaction@intimidation@cop@unarmed')
 
     while true do
-        Wait(250)
+        local sleep = 250
         if DoesEntityExist(ped) and not IsEntityDead(ped) then
             local newWeap = GetSelectedPedWeapon(ped)
             if newWeap ~= currWeap then
-                local pos, rot = GetEntityCoords(ped), GetEntityHeading(ped)
-                SetCurrentPedWeapon(ped, currWeap, true)
-
                 local holsterVariant = GetPedDrawableVariation(ped, 7)
                 local wearingHolster = Config.WeapDraw.variants[holsterVariant] ~= nil
 
-                if checkWeapon(newWeap) then
-                    if holstered and wearingHolster then
+                if checkWeapon(newWeap) then -- Drawing a weapon
+                    if holstered and wearingHolster and not IsEntityPlayingAnim(ped, 'rcmjosh4', 'josh_leadout_cop2', 3) then
                         canFire = false
                         CeaseFire()
-                        loadAnimDict('rcmjosh4')
-                        TaskPlayAnimAdvanced(ped, 'rcmjosh4', 'josh_leadout_cop2', pos.x, pos.y, pos.z, 0, 0, rot, 3.0, 3.0, -1, 50, 0, 0, 0)
+                        TaskPlayAnim(ped, 'rcmjosh4', 'josh_leadout_cop2', 3.0, 3.0, -1, 50, 0, false, false, false)
                         Wait(300)
-                        SetCurrentPedWeapon(ped, newWeap, true)
 
-                        local newDrawable = Config.WeapDraw.variants[holsterVariant]
-                        if newDrawable then
-                            SetPedComponentVariation(ped, 7, newDrawable, GetPedTextureVariation(ped,7), 2)
+                        local emptyDrawable = Config.WeapDraw.variants[holsterVariant]
+                        if emptyDrawable and emptyDrawable ~= holsterVariant then
+                            SetPedComponentVariation(ped, 7, emptyDrawable, GetPedTextureVariation(ped, 7), 2)
                         end
 
-                        currWeap = newWeap
-                        Wait(300)
-                        ClearPedTasks(ped)
-                        holstered = false
-                        canFire = true
-                    else
                         SetCurrentPedWeapon(ped, newWeap, true)
                         currWeap = newWeap
                         holstered = false
                         canFire = true
+                        ClearPedTasks(ped)
+                    elseif newWeap ~= `WEAPON_UNARMED` then
+                        SetCurrentPedWeapon(ped, newWeap, true)
+                        currWeap = newWeap
+                        holstered = false
                     end
-                elseif currWeap ~= `WEAPON_UNARMED` and isWeaponHolsterable(currWeap) and wearingHolster then
-                    local newDrawable = Config.WeapDraw.variants[holsterVariant]
-                    if newDrawable then
-                        SetPedComponentVariation(ped, 7, newDrawable, currHolsterTexture, 2)
+
+                    if newWeap == `WEAPON_UNARMED` and currWeap ~= `WEAPON_UNARMED` and wearingHolster and isWeaponHolsterable(currWeap) and not IsEntityPlayingAnim(ped, 'reaction@intimidation@cop@unarmed', 'intro', 3) then
+                        canFire = false
+                        CeaseFire()
+                        TaskPlayAnim(ped, 'reaction@intimidation@cop@unarmed', 'intro', 3.0, 3.0, -1, 50, 0, false, false, false)
+                        Wait(300)
+
+                        local holsteredDrawable = Config.WeapDraw.variants[holsterVariant]
+                        if holsteredDrawable and holsteredDrawable ~= holsterVariant then
+                            SetPedComponentVariation(ped, 7, holsteredDrawable, GetPedTextureVariation(ped, 7), 2)
+                        end
+
+                        SetCurrentPedWeapon(ped, `WEAPON_UNARMED`, true)
+                        currWeap = `WEAPON_UNARMED`
+                        holstered = true
+                        canFire = true
+                        ClearPedTasks(ped)
                     end
-                    SetCurrentPedWeapon(ped, `WEAPON_UNARMED`, true)
-                    currWeap = `WEAPON_UNARMED`
-                    holstered = true
-                    ClearPedTasks(ped)
-                else
-                    SetCurrentPedWeapon(ped, newWeap, true)
-                    currWeap = newWeap
-                    holstered = false
                 end
             end
         end
-    Wait(0)
+        Wait(250)
     end
 end)
+
 
 
 function CeaseFire()

--- a/client/weapdraw.lua
+++ b/client/weapdraw.lua
@@ -103,6 +103,7 @@ local weapons = {
 }
 
 local currHolsterTexture = nil
+local canFire = false
 
 local function loadAnimDict(dict)
     if HasAnimDictLoaded(dict) then return end

--- a/client/weapdraw.lua
+++ b/client/weapdraw.lua
@@ -102,7 +102,6 @@ local weapons = {
     'WEAPON_STONE_HATCHET'
 }
 
-local currHolsterTexture = nil
 local canFire = false
 
 local function loadAnimDict(dict)
@@ -136,7 +135,6 @@ RegisterNetEvent('qb-weapons:ResetHolster', function()
     canFire = true
     currWeap = `WEAPON_UNARMED`
     currHolster = nil
-    currHolsterTexture = nil
     wearingHolster = nil
 end)
 
@@ -146,13 +144,12 @@ RegisterNetEvent('qb-weapons:client:DrawWeapon', function()
     local ped = PlayerPedId()
     local currWeap = `WEAPON_UNARMED`
     local holstered = true
-    local canFire = true
+    canFire = true
 
     loadAnimDict('rcmjosh4')
     loadAnimDict('reaction@intimidation@cop@unarmed')
 
     while true do
-        local sleep = 250
         if DoesEntityExist(ped) and not IsEntityDead(ped) then
             local newWeap = GetSelectedPedWeapon(ped)
             if newWeap ~= currWeap then

--- a/client/weapdraw.lua
+++ b/client/weapdraw.lua
@@ -102,13 +102,8 @@ local weapons = {
     'WEAPON_STONE_HATCHET'
 }
 
-local holstered = true
 local canFire = true
-local currWeap = `WEAPON_UNARMED`
-local currHolster = nil
 local currHolsterTexture = nil
-local wearingHolster = nil
-
 
 local function loadAnimDict(dict)
     if HasAnimDictLoaded(dict) then return end

--- a/client/weapdraw.lua
+++ b/client/weapdraw.lua
@@ -109,6 +109,7 @@ local currHolster = nil
 local currHolsterTexture = nil
 local wearingHolster = nil
 
+
 local function loadAnimDict(dict)
     if HasAnimDictLoaded(dict) then return end
     RequestAnimDict(dict)
@@ -146,185 +147,66 @@ end)
 
 RegisterNetEvent('qb-weapons:client:DrawWeapon', function()
     if GetResourceState('qb-inventory') == 'missing' then return end
-    local sleep
-    local weaponCheck = 0
+
+    local ped, currWeap = PlayerPedId(), `WEAPON_UNARMED`
+    local holstered, canFire = true, true
+
     while true do
-        local ped = PlayerPedId()
-        sleep = 250
-        if DoesEntityExist(ped) and not IsEntityDead(ped) and not IsPedInParachuteFreeFall(ped) and not IsPedFalling(ped) and (GetPedParachuteState(ped) == -1 or GetPedParachuteState(ped) == 0) then
-            sleep = 0
-            if currWeap ~= GetSelectedPedWeapon(ped) then
-                local pos = GetEntityCoords(ped, true)
-                local rot = GetEntityHeading(ped)
-
-                local newWeap = GetSelectedPedWeapon(ped)
+        Wait(250)
+        if DoesEntityExist(ped) and not IsEntityDead(ped) then
+            local newWeap = GetSelectedPedWeapon(ped)
+            if newWeap ~= currWeap then
+                local pos, rot = GetEntityCoords(ped), GetEntityHeading(ped)
                 SetCurrentPedWeapon(ped, currWeap, true)
-                loadAnimDict('reaction@intimidation@1h')
-                loadAnimDict('reaction@intimidation@cop@unarmed')
-                loadAnimDict('rcmjosh4')
-                loadAnimDict('weapons@pistol@')
 
-                local holsterVariant = GetPedDrawableVariation(ped, 8)
-                wearingHolster = false
-                for i = 1, #Config.WeapDraw.variants, 1 do
-                    if holsterVariant == Config.WeapDraw.variants[i] then
-                        wearingHolster = true
-                    end
-                end
+                local holsterVariant = GetPedDrawableVariation(ped, 7)
+                local wearingHolster = Config.WeapDraw.variants[holsterVariant] ~= nil
+
                 if checkWeapon(newWeap) then
-                    if holstered then
-                        if wearingHolster then
-                            --TaskPlayAnim(ped, 'rcmjosh4', 'josh_leadout_cop2', 8.0, 2.0, -1, 48, 10, 0, 0, 0 )
-                            canFire = false
-                            CeaseFire()
-                            currHolster = GetPedDrawableVariation(ped, 7)
-                            currHolsterTexture = GetPedTextureVariation(ped, 7)
-                            TaskPlayAnimAdvanced(ped, 'rcmjosh4', 'josh_leadout_cop2', pos.x, pos.y, pos.z, 0, 0, rot, 3.0, 3.0, -1, 50, 0, 0, 0)
-                            Wait(300)
-                            SetCurrentPedWeapon(ped, newWeap, true)
-
-                            if isWeaponHolsterable(newWeap) then
-                                SetPedComponentVariation(ped, 7, currHolster == 8 and 2 or currHolster == 1 and 3 or currHolster == 6 and 5, currHolsterTexture, 2)
-                            end
-                            currWeap = newWeap
-                            Wait(300)
-                            ClearPedTasks(ped)
-                            holstered = false
-                            canFire = true
-                        else
-                            canFire = false
-                            CeaseFire()
-                            TaskPlayAnimAdvanced(ped, 'reaction@intimidation@1h', 'intro', pos.x, pos.y, pos.z, 0, 0, rot, 8.0, 3.0, -1, 50, 0, 0, 0)
-                            Wait(1000)
-                            SetCurrentPedWeapon(ped, newWeap, true)
-                            currWeap = newWeap
-                            Wait(1400)
-                            ClearPedTasks(ped)
-                            holstered = false
-                            canFire = true
-                        end
-                    elseif newWeap ~= currWeap and checkWeapon(currWeap) then
-                        if wearingHolster then
-                            canFire = false
-                            CeaseFire()
-
-                            TaskPlayAnimAdvanced(ped, 'reaction@intimidation@cop@unarmed', 'intro', pos.x, pos.y, pos.z, 0, 0, rot, 3.0, 3.0, -1, 50, 0, 0, 0)
-                            Wait(500)
-
-                            if isWeaponHolsterable(currWeap) then
-                                SetPedComponentVariation(ped, 7, currHolster, currHolsterTexture, 2)
-                            end
-
-                            SetCurrentPedWeapon(ped, `WEAPON_UNARMED`, true)
-                            currHolster = GetPedDrawableVariation(ped, 7)
-                            currHolsterTexture = GetPedTextureVariation(ped, 7)
-
-                            TaskPlayAnimAdvanced(ped, 'rcmjosh4', 'josh_leadout_cop2', pos.x, pos.y, pos.z, 0, 0, rot, 3.0, 3.0, -1, 50, 0, 0, 0)
-                            Wait(300)
-                            SetCurrentPedWeapon(ped, newWeap, true)
-
-                            if isWeaponHolsterable(newWeap) then
-                                SetPedComponentVariation(ped, 7, currHolster == 8 and 2 or currHolster == 1 and 3 or currHolster == 6 and 5, currHolsterTexture, 2)
-                            end
-
-                            Wait(500)
-                            currWeap = newWeap
-                            ClearPedTasks(ped)
-                            holstered = false
-                            canFire = true
-                        else
-                            canFire = false
-                            CeaseFire()
-                            TaskPlayAnimAdvanced(ped, 'reaction@intimidation@1h', 'outro', pos.x, pos.y, pos.z, 0, 0, rot, 8.0, 3.0, -1, 50, 0, 0, 0)
-                            Wait(1600)
-                            SetCurrentPedWeapon(ped, `WEAPON_UNARMED`, true)
-                            TaskPlayAnimAdvanced(ped, 'reaction@intimidation@1h', 'intro', pos.x, pos.y, pos.z, 0, 0, rot, 8.0, 3.0, -1, 50, 0, 0, 0)
-                            Wait(1000)
-                            SetCurrentPedWeapon(ped, newWeap, true)
-                            currWeap = newWeap
-                            Wait(1400)
-                            ClearPedTasks(ped)
-                            holstered = false
-                            canFire = true
-                        end
-                    else
-                        if wearingHolster then
-                            SetCurrentPedWeapon(ped, `WEAPON_UNARMED`, true)
-                            currHolster = GetPedDrawableVariation(ped, 7)
-                            currHolsterTexture = GetPedTextureVariation(ped, 7)
-                            TaskPlayAnimAdvanced(ped, 'rcmjosh4', 'josh_leadout_cop2', pos.x, pos.y, pos.z, 0, 0, rot, 3.0, 3.0, -1, 50, 0, 0, 0)
-                            Wait(300)
-                            SetCurrentPedWeapon(ped, newWeap, true)
-
-                            if isWeaponHolsterable(newWeap) then
-                                SetPedComponentVariation(ped, 7, currHolster == 8 and 2 or currHolster == 1 and 3 or currHolster == 6 and 5, currHolsterTexture, 2)
-                            end
-
-                            currWeap = newWeap
-                            Wait(300)
-                            ClearPedTasks(ped)
-                            holstered = false
-                            canFire = true
-                        else
-                            SetCurrentPedWeapon(ped, `WEAPON_UNARMED`, true)
-                            TaskPlayAnimAdvanced(ped, 'reaction@intimidation@1h', 'intro', pos.x, pos.y, pos.z, 0, 0, rot, 8.0, 3.0, -1, 50, 0, 0, 0)
-                            Wait(1000)
-                            SetCurrentPedWeapon(ped, newWeap, true)
-                            currWeap = newWeap
-                            Wait(1400)
-                            ClearPedTasks(ped)
-                            holstered = false
-                            canFire = true
-                        end
-                    end
-                else
-                    if not holstered and checkWeapon(currWeap) then
-                        if wearingHolster then
-                            canFire = false
-                            CeaseFire()
-                            TaskPlayAnimAdvanced(ped, 'reaction@intimidation@cop@unarmed', 'intro', pos.x, pos.y, pos.z, 0, 0, rot, 3.0, 3.0, -1, 50, 0, 0, 0)
-                            Wait(500)
-
-                            if isWeaponHolsterable(currWeap) then
-                                SetPedComponentVariation(ped, 7, currHolster, currHolsterTexture, 2)
-                            end
-
-                            SetCurrentPedWeapon(ped, `WEAPON_UNARMED`, true)
-                            ClearPedTasks(ped)
-                            SetCurrentPedWeapon(ped, newWeap, true)
-                            holstered = true
-                            canFire = true
-                            currWeap = newWeap
-                        else
-                            canFire = false
-                            CeaseFire()
-                            TaskPlayAnimAdvanced(ped, 'reaction@intimidation@1h', 'outro', pos.x, pos.y, pos.z, 0, 0, rot, 8.0, 3.0, -1, 50, 0, 0, 0)
-                            Wait(1400)
-                            SetCurrentPedWeapon(ped, `WEAPON_UNARMED`, true)
-                            ClearPedTasks(ped)
-                            SetCurrentPedWeapon(ped, newWeap, true)
-                            holstered = true
-                            canFire = true
-                            currWeap = newWeap
-                        end
-                    else
+                    if holstered and wearingHolster then
+                        canFire = false
+                        CeaseFire()
+                        loadAnimDict('rcmjosh4')
+                        TaskPlayAnimAdvanced(ped, 'rcmjosh4', 'josh_leadout_cop2', pos.x, pos.y, pos.z, 0, 0, rot, 3.0, 3.0, -1, 50, 0, 0, 0)
+                        Wait(300)
                         SetCurrentPedWeapon(ped, newWeap, true)
+
+                        local newDrawable = Config.WeapDraw.variants[holsterVariant]
+                        if newDrawable then
+                            SetPedComponentVariation(ped, 7, newDrawable, GetPedTextureVariation(ped,7), 2)
+                        end
+
+                        currWeap = newWeap
+                        Wait(300)
+                        ClearPedTasks(ped)
                         holstered = false
                         canFire = true
+                    else
+                        SetCurrentPedWeapon(ped, newWeap, true)
                         currWeap = newWeap
+                        holstered = false
+                        canFire = true
                     end
+                elseif currWeap ~= `WEAPON_UNARMED` and isWeaponHolsterable(currWeap) and wearingHolster then
+                    local newDrawable = Config.WeapDraw.variants[holsterVariant]
+                    if newDrawable then
+                        SetPedComponentVariation(ped, 7, newDrawable, currHolsterTexture, 2)
+                    end
+                    SetCurrentPedWeapon(ped, `WEAPON_UNARMED`, true)
+                    currWeap = `WEAPON_UNARMED`
+                    holstered = true
+                    ClearPedTasks(ped)
+                else
+                    SetCurrentPedWeapon(ped, newWeap, true)
+                    currWeap = newWeap
+                    holstered = false
                 end
             end
         end
-        Wait(sleep)
-        if currWeap == nil or currWeap == `WEAPON_UNARMED` then
-            weaponCheck += 1
-            if weaponCheck == 2 then
-                break
-            end
-        end
+    Wait(0)
     end
 end)
+
 
 function CeaseFire()
     CreateThread(function()


### PR DESCRIPTION
Changed code from cumbersome check code, to just checking for variant and switching to opposite.  Also makes it easier to implement new holsters if others are added to EUP by simply putting variants in config file and not having to add to logic code.

**Describe Pull request**
Code was changed to facilitate checking variant pairs from new config.lua. Then simply switching the componentID based on the current componentID.  So in the config, as an example, I have:

[205] = 204  -- Full to empty
[204] = 205  -- Empty to full

This way you can simply edit the config and not have to change the cumbersome logic in weapdraw.lua.

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest) yes
- Does your code fit the style guidelines? [yes/no] yes
- Does your PR fit the contribution guidelines? [yes/no] yes
