### PR TITLE
Fix throwable weapons not working

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -127,14 +127,12 @@ RegisterNetEvent('qb-weapons:client:UseWeapon', function(weaponData, shootbool)
         TriggerEvent('qb-weapons:client:SetCurrentWeapon', nil, shootbool)
         currentWeapon = nil
     elseif weaponName == 'weapon_stickybomb' or weaponName == 'weapon_pipebomb' or weaponName == 'weapon_smokegrenade' or weaponName == 'weapon_flare' or weaponName == 'weapon_proxmine' or weaponName == 'weapon_ball' or weaponName == 'weapon_molotov' or weaponName == 'weapon_grenade' or weaponName == 'weapon_bzgas' then
-        TriggerEvent('qb-weapons:client:DrawWeapon', weaponName)
         GiveWeaponToPed(ped, weaponHash, 1, false, false)
         SetPedAmmo(ped, weaponHash, 1)
         SetCurrentPedWeapon(ped, weaponHash, true)
         TriggerEvent('qb-weapons:client:SetCurrentWeapon', weaponData, shootbool)
         currentWeapon = weaponName
     elseif weaponName == 'weapon_snowball' then
-        TriggerEvent('qb-weapons:client:DrawWeapon', weaponName)
         GiveWeaponToPed(ped, weaponHash, 10, false, false)
         SetPedAmmo(ped, weaponHash, 10)
         SetCurrentPedWeapon(ped, weaponHash, true)


### PR DESCRIPTION
## Summary
- Removes the `DrawWeapon` event trigger for throwable weapons and snowball
- The draw animation system was blocking firing controls, preventing throws

## Root Cause
The `qb-weapons:client:DrawWeapon` event triggers an animation system in `weapdraw.lua` that:
1. Sets `canFire = false`
2. Calls `CeaseFire()` which runs a loop calling `DisablePlayerFiring()`
3. This blocks the player's ability to throw until the animation completes

For throwables (single-use, instant-equip items), this draw animation is unnecessary and causes the "not thrown" bug.

## Test plan
- [ ] Give yourself `weapon_bzgas` and verify you can throw it immediately
- [ ] Test other throwables: grenade, molotov, stickybomb, pipebomb, smokegrenade, flare, proxmine, ball
- [ ] Test snowball works correctly
- [ ] Verify regular weapons still have their draw animations

## References
Fixes qbcore-framework/qb-inventory#638