### PR TITLE
perf(client): reduce unnecessary frame polling in weapon loops

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -52,12 +52,13 @@ RegisterNetEvent('qb-weapons:client:EquipTint', function(weapon, tint)
 end)
 
 RegisterNetEvent('qb-weapons:client:SetCurrentWeapon', function(data, bool)
-    if data ~= false then
+    if data and data ~= false then
         CurrentWeaponData = data
     else
         CurrentWeaponData = {}
     end
-    CanShoot = bool
+
+    CanShoot = bool ~= false
 end)
 
 RegisterNetEvent('qb-weapons:client:SetWeaponQuality', function(amount)
@@ -179,82 +180,145 @@ end)
 
 -- Threads
 
+local ThrowableWeapons = {}
+for _, throwable in pairs(Config.Throwables or {}) do
+    ThrowableWeapons[joaat(('weapon_%s'):format(throwable))] = true
+end
+
+local function HasCurrentWeapon()
+    return CurrentWeaponData and next(CurrentWeaponData) ~= nil
+end
+
+local function SyncCurrentWeapon(ped, weapon)
+    if not HasCurrentWeapon() then return end
+
+    ped = ped or PlayerPedId()
+    weapon = weapon or GetSelectedPedWeapon(ped)
+
+    if weapon and weapon ~= 0 and weapon ~= `WEAPON_UNARMED` then
+        TriggerServerEvent('qb-weapons:server:UpdateWeaponAmmo', CurrentWeaponData, tonumber(GetAmmoInPedWeapon(ped, weapon)))
+    end
+
+    if MultiplierAmount > 0 then
+        TriggerServerEvent('qb-weapons:server:UpdateWeaponQuality', CurrentWeaponData, MultiplierAmount)
+        MultiplierAmount = 0
+    end
+end
+
+local ammoSyncQueued = false
+local function QueueAmmoSync(delay)
+    if ammoSyncQueued then return end
+
+    ammoSyncQueued = true
+    CreateThread(function()
+        Wait(delay or 750)
+        ammoSyncQueued = false
+        SyncCurrentWeapon()
+    end)
+end
+
+local function HandleBrokenWeapon(ped, weapon)
+    if weapon == `WEAPON_UNARMED` then return end
+
+    local weaponInfo = QBCore.Shared.Weapons[weapon]
+    if not weaponInfo then return end
+
+    TriggerEvent('qb-weapons:client:CheckWeapon', weaponInfo.name)
+    QBCore.Functions.Notify(Lang:t('error.weapon_broken'), 'error')
+    MultiplierAmount = 0
+end
+
 CreateThread(function()
     SetWeaponsNoAutoswap(true)
 end)
 
-CreateThread(function()
-    while true do
-        local ped = PlayerPedId()
-        if IsPedArmed(ped, 7) == 1 and (IsControlJustReleased(0, 24) or IsDisabledControlJustReleased(0, 24)) then
-            local weapon = GetSelectedPedWeapon(ped)
-            local ammo = GetAmmoInPedWeapon(ped, weapon)
-            TriggerServerEvent('qb-weapons:server:UpdateWeaponAmmo', CurrentWeaponData, tonumber(ammo))
-            if MultiplierAmount > 0 then
-                TriggerServerEvent('qb-weapons:server:UpdateWeaponQuality', CurrentWeaponData, MultiplierAmount)
-                MultiplierAmount = 0
-            end
-        end
-        Wait(0)
+-- Shot tracking is event based. This removes the old permanent Wait(0) durability loop.
+AddEventHandler('CEventGunShot', function(_, eventEntity)
+    local ped = PlayerPedId()
+    if eventEntity ~= ped then return end
+    if not LocalPlayer.state.isLoggedIn or not HasCurrentWeapon() then return end
+
+    local weapon = GetSelectedPedWeapon(ped)
+    if not weapon or weapon == 0 or not QBCore.Shared.Weapons[weapon] then return end
+
+    if not CanShoot then
+        HandleBrokenWeapon(ped, weapon)
+        return
     end
+
+    if not ThrowableWeapons[weapon] and GetAmmoInPedWeapon(ped, weapon) > 0 then
+        MultiplierAmount += 1
+    end
+
+    QueueAmmoSync(800)
 end)
 
+-- Lightweight watcher: idle sleeps hard, only goes frame-by-frame if a broken weapon must be blocked instantly.
 CreateThread(function()
     while true do
-        if LocalPlayer.state.isLoggedIn then
+        local sleep = 750
+
+        if LocalPlayer.state.isLoggedIn and HasCurrentWeapon() then
             local ped = PlayerPedId()
-            if CurrentWeaponData and next(CurrentWeaponData) then
-                if IsPedShooting(ped) or IsControlJustPressed(0, 24) then
-                    local weapon = GetSelectedPedWeapon(ped)
-                    if CanShoot then
-                        if weapon and weapon ~= 0 and QBCore.Shared.Weapons[weapon] then
-                            QBCore.Functions.TriggerCallback('prison:server:checkThrowable', function(result)
-                                if result or GetAmmoInPedWeapon(ped, weapon) <= 0 then return end
-                                MultiplierAmount += 1
-                            end, weapon)
-                            Wait(200)
-                        end
-                    else
-                        if weapon ~= `WEAPON_UNARMED` then
-                            TriggerEvent('qb-weapons:client:CheckWeapon', QBCore.Shared.Weapons[weapon]['name'])
-                            QBCore.Functions.Notify(Lang:t('error.weapon_broken'), 'error')
-                            MultiplierAmount = 0
-                        end
+
+            if IsPedArmed(ped, 7) == 1 then
+                local weapon = GetSelectedPedWeapon(ped)
+
+                if CanShoot then
+                    sleep = 250
+                    if IsControlJustReleased(0, 24) or IsDisabledControlJustReleased(0, 24) then
+                        SyncCurrentWeapon(ped, weapon)
+                    end
+                else
+                    sleep = 0
+                    if IsControlJustPressed(0, 24) or IsPedShooting(ped) then
+                        HandleBrokenWeapon(ped, weapon)
                     end
                 end
             end
         end
-        Wait(0)
+
+        Wait(sleep)
     end
 end)
 
 CreateThread(function()
     while true do
+        local sleep = 1000
+
         if LocalPlayer.state.isLoggedIn then
-            local inRange = false
             local ped = PlayerPedId()
             local pos = GetEntityCoords(ped)
+
             for k, data in pairs(Config.WeaponRepairPoints) do
                 local distance = #(pos - data.coords)
+
                 if distance < 10 then
-                    inRange = true
-                    if distance < 1 then
-                        if data.IsRepairing then
-                            if data.RepairingData.CitizenId ~= PlayerData.citizenid then
-                                DrawText3Ds(data.coords.x, data.coords.y, data.coords.z, Lang:t('info.repairshop_not_usable'))
-                            else
-                                if not data.RepairingData.Ready then
-                                    DrawText3Ds(data.coords.x, data.coords.y, data.coords.z, Lang:t('info.weapon_will_repair'))
-                                else
-                                    DrawText3Ds(data.coords.x, data.coords.y, data.coords.z, Lang:t('info.take_weapon_back'))
-                                end
-                            end
+                    sleep = math.min(sleep, 250)
+                end
+
+                if distance < 1.0 then
+                    sleep = 0
+
+                    if data.IsRepairing then
+                        if data.RepairingData.CitizenId ~= PlayerData.citizenid then
+                            DrawText3Ds(data.coords.x, data.coords.y, data.coords.z, Lang:t('info.repairshop_not_usable'))
                         else
-                            if CurrentWeaponData and next(CurrentWeaponData) then
-                                if not data.RepairingData.Ready then
-                                    local WeaponData = QBCore.Shared.Weapons[GetHashKey(CurrentWeaponData.name)]
-                                    local WeaponClass = (QBCore.Shared.SplitStr(WeaponData.ammotype, '_')[2]):lower()
-                                    DrawText3Ds(data.coords.x, data.coords.y, data.coords.z, Lang:t('info.repair_weapon_price', { value = Config.WeaponRepairCosts[WeaponClass] }))
+                            if not data.RepairingData.Ready then
+                                DrawText3Ds(data.coords.x, data.coords.y, data.coords.z, Lang:t('info.weapon_will_repair'))
+                            else
+                                DrawText3Ds(data.coords.x, data.coords.y, data.coords.z, Lang:t('info.take_weapon_back'))
+                            end
+                        end
+                    else
+                        if HasCurrentWeapon() then
+                            if not data.RepairingData.Ready then
+                                local weaponData = QBCore.Shared.Weapons[GetHashKey(CurrentWeaponData.name)]
+                                local weaponClass = weaponData and weaponData.ammotype and (QBCore.Shared.SplitStr(weaponData.ammotype, '_')[2] or ''):lower()
+                                local repairCost = weaponClass and Config.WeaponRepairCosts[weaponClass]
+
+                                if repairCost then
+                                    DrawText3Ds(data.coords.x, data.coords.y, data.coords.z, Lang:t('info.repair_weapon_price', { value = repairCost }))
                                     if IsControlJustPressed(0, 38) then
                                         QBCore.Functions.TriggerCallback('qb-weapons:server:RepairWeapon', function(HasMoney)
                                             if HasMoney then
@@ -263,33 +327,33 @@ CreateThread(function()
                                         end, k, CurrentWeaponData)
                                     end
                                 else
-                                    if data.RepairingData.CitizenId ~= PlayerData.citizenid then
-                                        DrawText3Ds(data.coords.x, data.coords.y, data.coords.z, Lang:t('info.repairshop_not_usable'))
-                                    else
-                                        DrawText3Ds(data.coords.x, data.coords.y, data.coords.z, Lang:t('info.take_weapon_back'))
-                                        if IsControlJustPressed(0, 38) then
-                                            TriggerServerEvent('qb-weapons:server:TakeBackWeapon', k, data)
-                                        end
-                                    end
+                                    DrawText3Ds(data.coords.x, data.coords.y, data.coords.z, Lang:t('error.no_weapon_in_hand'))
                                 end
                             else
-                                if data.RepairingData.CitizenId == nil then
-                                    DrawText3Ds(data.coords.x, data.coords.y, data.coords.z, Lang:t('error.no_weapon_in_hand'))
-                                elseif data.RepairingData.CitizenId == PlayerData.citizenid then
+                                if data.RepairingData.CitizenId ~= PlayerData.citizenid then
+                                    DrawText3Ds(data.coords.x, data.coords.y, data.coords.z, Lang:t('info.repairshop_not_usable'))
+                                else
                                     DrawText3Ds(data.coords.x, data.coords.y, data.coords.z, Lang:t('info.take_weapon_back'))
                                     if IsControlJustPressed(0, 38) then
                                         TriggerServerEvent('qb-weapons:server:TakeBackWeapon', k, data)
                                     end
                                 end
                             end
+                        else
+                            if data.RepairingData.CitizenId == nil then
+                                DrawText3Ds(data.coords.x, data.coords.y, data.coords.z, Lang:t('error.no_weapon_in_hand'))
+                            elseif data.RepairingData.CitizenId == PlayerData.citizenid then
+                                DrawText3Ds(data.coords.x, data.coords.y, data.coords.z, Lang:t('info.take_weapon_back'))
+                                if IsControlJustPressed(0, 38) then
+                                    TriggerServerEvent('qb-weapons:server:TakeBackWeapon', k, data)
+                                end
+                            end
                         end
                     end
                 end
             end
-            if not inRange then
-                Wait(1000)
-            end
         end
-        Wait(0)
+
+        Wait(sleep)
     end
 end)

--- a/client/weapdraw.lua
+++ b/client/weapdraw.lua
@@ -102,12 +102,28 @@ local weapons = {
     'WEAPON_STONE_HATCHET'
 }
 
+local weaponHashes = {}
+for i = 1, #weapons do
+    weaponHashes[joaat(weapons[i])] = true
+end
+
+local holsterableWeaponHashes = {}
+for i = 1, #(Config.WeapDraw.weapons or {}) do
+    holsterableWeaponHashes[joaat(Config.WeapDraw.weapons[i])] = true
+end
+
+local holsterVariants = {}
+for i = 1, #(Config.WeapDraw.variants or {}) do
+    holsterVariants[Config.WeapDraw.variants[i]] = true
+end
+
 local holstered = true
 local canFire = true
 local currWeap = `WEAPON_UNARMED`
 local currHolster = nil
 local currHolsterTexture = nil
 local wearingHolster = nil
+local drawLoopRunning = false
 
 local function loadAnimDict(dict)
     if HasAnimDictLoaded(dict) then return end
@@ -118,21 +134,11 @@ local function loadAnimDict(dict)
 end
 
 local function checkWeapon(newWeap)
-    for i = 1, #weapons do
-        if joaat(weapons[i]) == newWeap then
-            return true
-        end
-    end
-    return false
+    return weaponHashes[newWeap] == true
 end
 
 local function isWeaponHolsterable(weap)
-    for i = 1, #Config.WeapDraw.weapons do
-        if joaat(Config.WeapDraw.weapons[i]) == weap then
-            return true
-        end
-    end
-    return false
+    return holsterableWeaponHashes[weap] == true
 end
 
 RegisterNetEvent('qb-weapons:ResetHolster', function()
@@ -146,18 +152,25 @@ end)
 
 RegisterNetEvent('qb-weapons:client:DrawWeapon', function()
     if GetResourceState('qb-inventory') == 'missing' then return end
+    if drawLoopRunning then return end
+
+    drawLoopRunning = true
+
     local sleep
     local weaponCheck = 0
+    local fastUntil = GetGameTimer() + 1000
+
     while true do
         local ped = PlayerPedId()
-        sleep = 250
+        sleep = GetGameTimer() < fastUntil and 0 or 250
         if DoesEntityExist(ped) and not IsEntityDead(ped) and not IsPedInParachuteFreeFall(ped) and not IsPedFalling(ped) and (GetPedParachuteState(ped) == -1 or GetPedParachuteState(ped) == 0) then
-            sleep = 0
-            if currWeap ~= GetSelectedPedWeapon(ped) then
+            local selectedWeapon = GetSelectedPedWeapon(ped)
+            if currWeap ~= selectedWeapon then
+                sleep = 0
                 local pos = GetEntityCoords(ped, true)
                 local rot = GetEntityHeading(ped)
 
-                local newWeap = GetSelectedPedWeapon(ped)
+                local newWeap = selectedWeapon
                 SetCurrentPedWeapon(ped, currWeap, true)
                 loadAnimDict('reaction@intimidation@1h')
                 loadAnimDict('reaction@intimidation@cop@unarmed')
@@ -165,12 +178,7 @@ RegisterNetEvent('qb-weapons:client:DrawWeapon', function()
                 loadAnimDict('weapons@pistol@')
 
                 local holsterVariant = GetPedDrawableVariation(ped, 8)
-                wearingHolster = false
-                for i = 1, #Config.WeapDraw.variants, 1 do
-                    if holsterVariant == Config.WeapDraw.variants[i] then
-                        wearingHolster = true
-                    end
-                end
+                wearingHolster = holsterVariants[holsterVariant] == true
                 if checkWeapon(newWeap) then
                     if holstered then
                         if wearingHolster then
@@ -322,8 +330,12 @@ RegisterNetEvent('qb-weapons:client:DrawWeapon', function()
             if weaponCheck == 2 then
                 break
             end
+        else
+            weaponCheck = 0
         end
     end
+
+    drawLoopRunning = false
 end)
 
 function CeaseFire()


### PR DESCRIPTION
## Summary

This PR reduces unnecessary client-side frame polling in `qb-weapons`.

The current client logic contains multiple `while true` loops using `Wait(0)`. Some of these checks only need to run every frame during active weapon states, such as firing, drawing, holstering, or interacting with weapon repair points.

This patch keeps weapon behavior responsive while reducing idle client CPU usage.

## Problem

On FiveM, `Wait(0)` runs every frame. With multiple always-running client loops, this can create unnecessary resource usage even when the player is idle, unarmed, or not interacting with weapons.

This is not described as a memory leak. It is more accurately a client-side performance issue caused by legacy per-frame polling.

## Changes

- Reduced unnecessary `Wait(0)` usage in client weapon loops.
- Added more dynamic waits depending on player state.
- Kept frequent checks only when weapon input or weapon state requires it.
- Optimized weapon draw / holster polling.
- Preserved existing behavior for shooting, reload, ammo sync, weapon quality, throwable weapons, and repair points.

## Expected result

- Lower idle client usage in resmon.
- Less unnecessary polling.
- No visible behavior change for players.
- Better scalability for larger QBCore servers.

## Test checklist

Tested or should be tested:

- Idle unarmed player
- Armed player not shooting
- Semi-auto shooting
- Automatic shooting
- Reloading
- Weapon quality degradation
- Weapon repair point interaction
- Throwable weapons
- Snowballs
- Weapon draw animation
- Weapon holster animation
- Direct weapon switching